### PR TITLE
fix: バトルエンジンの重大バグ6件を修正

### DIFF
--- a/src/engine/battle/__tests__/damage.test.ts
+++ b/src/engine/battle/__tests__/damage.test.ts
@@ -163,9 +163,7 @@ describe("calculateDamage", () => {
     });
 
     expect(result.effectiveness).toBe(0);
-    // ダメージ計算式上、effectiveness=0 なので floor 後は0。
-    // ただしmax(1, ...)があるので最終的に1になる（ゲームの仕様差異）。
-    // 本実装ではmax(1)を適用している（将来的に無効判定は別レイヤーで処理）
+    expect(result.damage).toBe(0);
   });
 
   it("急所が出ると1.5倍になる", () => {

--- a/src/engine/battle/status.ts
+++ b/src/engine/battle/status.ts
@@ -64,6 +64,7 @@ export function applyStatusDamage(monster: MonsterInstance, maxHp: number): numb
 
 /**
  * 行動可能かチェック（眠り・氷の解除判定含む）
+ * 解除に成功した場合、monster.status を null にクリアする
  * @returns true = 行動可能
  */
 export function canAct(monster: MonsterInstance, random?: () => number): boolean {
@@ -71,17 +72,25 @@ export function canAct(monster: MonsterInstance, random?: () => number): boolean
   const rng = random ?? Math.random;
   const effect = getStatusEffect(monster.status);
 
-  // 眠り: 33%で起きる
+  // 眠り: 33%で起きる → 成功時にステータスクリア
   if (monster.status === "sleep") {
-    return rng() < 1 / 3;
+    if (rng() < 1 / 3) {
+      monster.status = null;
+      return true;
+    }
+    return false;
   }
 
-  // 氷: 20%で解凍
+  // 氷: 20%で解凍 → 成功時にステータスクリア
   if (monster.status === "freeze") {
-    return rng() < 0.2;
+    if (rng() < 0.2) {
+      monster.status = null;
+      return true;
+    }
+    return false;
   }
 
-  // 麻痺: 25%で行動不能
+  // 麻痺: 25%で行動不能（ステータスは残る）
   if (effect.immobilizeChance > 0) {
     return rng() >= effect.immobilizeChance;
   }


### PR DESCRIPTION
## Summary
監査で発見された重大バグ6件を修正し、各修正に対応するテストを追加。

## Bug fixes

| # | バグ | 修正箇所 |
|---|------|---------|
| 1 | 眠り・氷の解除後にステータスがクリアされない | `status.ts` canAct() |
| 2 | タイプ無効（effectiveness=0）で1ダメージ入る | `damage.ts` |
| 3 | PP=0でも技が使える | `move-executor.ts` |
| 4 | 逃走失敗時に相手ターンがスキップされる | `engine.ts` |
| 5 | やけど時の物理攻撃力半減が未適用 | `damage.ts` |
| 6 | ステータス技（さいみんじゅつ等）の効果が未実装 | `move-executor.ts` |

## Test plan
- [x] `bun run test` — 42テスト全通過（+7件のバグ修正検証テスト）
- [x] `bun run type-check` — 型チェック通過
- [x] `bun run lint` — ESLint通過（warning 0）
- [x] `bun run format:check` — フォーマット通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)