### PR TITLE
feat: パーティ・持ち物・技枠・進化システム (Epic 6)

### DIFF
--- a/src/engine/item/__tests__/bag.test.ts
+++ b/src/engine/item/__tests__/bag.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from "vitest";
+import {
+  createBag,
+  addItem,
+  removeItem,
+  getItemCount,
+  getItemsByCategory,
+  useHealItem,
+} from "../bag";
+import type { ItemDefinition, MonsterInstance } from "@/types";
+
+function createDummyMonster(hp: number = 30): MonsterInstance {
+  return {
+    speciesId: "test",
+    level: 10,
+    exp: 1000,
+    ivs: { hp: 15, atk: 15, def: 15, spAtk: 15, spDef: 15, speed: 15 },
+    evs: { hp: 0, atk: 0, def: 0, spAtk: 0, spDef: 0, speed: 0 },
+    currentHp: hp,
+    moves: [{ moveId: "tackle", currentPp: 10 }],
+    status: null,
+  };
+}
+
+const potion: ItemDefinition = {
+  id: "potion",
+  name: "キズぐすり",
+  description: "HPを20回復する",
+  category: "medicine",
+  price: 300,
+  usableInBattle: true,
+  effect: { type: "heal_hp", amount: 20 },
+};
+
+const antidote: ItemDefinition = {
+  id: "antidote",
+  name: "どくけし",
+  description: "毒を治す",
+  category: "medicine",
+  price: 100,
+  usableInBattle: true,
+  effect: { type: "heal_status", status: "poison" },
+};
+
+const fullHeal: ItemDefinition = {
+  id: "full-heal",
+  name: "なんでもなおし",
+  description: "状態異常を全て治す",
+  category: "medicine",
+  price: 600,
+  usableInBattle: true,
+  effect: { type: "heal_status", status: "all" },
+};
+
+const monsterBall: ItemDefinition = {
+  id: "monster-ball",
+  name: "モンスターボール",
+  description: "モンスターを捕まえるボール",
+  category: "ball",
+  price: 200,
+  usableInBattle: true,
+  effect: { type: "ball", catchRateModifier: 1 },
+};
+
+const itemResolver = (id: string): ItemDefinition => {
+  const map: Record<string, ItemDefinition> = {
+    potion,
+    antidote,
+    "full-heal": fullHeal,
+    "monster-ball": monsterBall,
+  };
+  return map[id];
+};
+
+describe("バッグ管理", () => {
+  it("空のバッグを作成できる", () => {
+    const bag = createBag();
+    expect(bag.items).toHaveLength(0);
+  });
+
+  it("アイテムを追加できる", () => {
+    const bag = createBag();
+    addItem(bag, "potion", 3);
+    expect(getItemCount(bag, "potion")).toBe(3);
+  });
+
+  it("同じアイテムを追加すると個数が加算される", () => {
+    const bag = createBag();
+    addItem(bag, "potion", 2);
+    addItem(bag, "potion", 5);
+    expect(getItemCount(bag, "potion")).toBe(7);
+  });
+
+  it("アイテムを消費できる", () => {
+    const bag = createBag();
+    addItem(bag, "potion", 3);
+    const result = removeItem(bag, "potion", 1);
+    expect(result).toBe(true);
+    expect(getItemCount(bag, "potion")).toBe(2);
+  });
+
+  it("個数が0になったらアイテムが削除される", () => {
+    const bag = createBag();
+    addItem(bag, "potion", 1);
+    removeItem(bag, "potion", 1);
+    expect(getItemCount(bag, "potion")).toBe(0);
+    expect(bag.items).toHaveLength(0);
+  });
+
+  it("所持数不足の場合は消費できない", () => {
+    const bag = createBag();
+    addItem(bag, "potion", 1);
+    const result = removeItem(bag, "potion", 2);
+    expect(result).toBe(false);
+    expect(getItemCount(bag, "potion")).toBe(1);
+  });
+
+  it("カテゴリでフィルタできる", () => {
+    const bag = createBag();
+    addItem(bag, "potion", 1);
+    addItem(bag, "antidote", 1);
+    addItem(bag, "monster-ball", 5);
+
+    const medicine = getItemsByCategory(bag, "medicine", itemResolver);
+    expect(medicine).toHaveLength(2);
+
+    const balls = getItemsByCategory(bag, "ball", itemResolver);
+    expect(balls).toHaveLength(1);
+  });
+
+  describe("回復アイテム使用", () => {
+    it("HPを回復できる", () => {
+      const monster = createDummyMonster(10);
+      const result = useHealItem(potion, monster, 50);
+      expect(result.used).toBe(true);
+      expect(monster.currentHp).toBe(30);
+    });
+
+    it("HP回復は最大HPを超えない", () => {
+      const monster = createDummyMonster(45);
+      const result = useHealItem(potion, monster, 50);
+      expect(result.used).toBe(true);
+      expect(monster.currentHp).toBe(50);
+    });
+
+    it("HP満タンなら使えない", () => {
+      const monster = createDummyMonster(50);
+      const result = useHealItem(potion, monster, 50);
+      expect(result.used).toBe(false);
+    });
+
+    it("瀕死のモンスターには使えない", () => {
+      const monster = createDummyMonster(0);
+      const result = useHealItem(potion, monster, 50);
+      expect(result.used).toBe(false);
+    });
+
+    it("毒を治せる", () => {
+      const monster = createDummyMonster(30);
+      monster.status = "poison";
+      const result = useHealItem(antidote, monster, 50);
+      expect(result.used).toBe(true);
+      expect(monster.status).toBeNull();
+    });
+
+    it("対象外の状態異常には使えない", () => {
+      const monster = createDummyMonster(30);
+      monster.status = "burn";
+      const result = useHealItem(antidote, monster, 50);
+      expect(result.used).toBe(false);
+      expect(monster.status).toBe("burn");
+    });
+
+    it("なんでもなおしで任意の状態異常を治せる", () => {
+      const monster = createDummyMonster(30);
+      monster.status = "paralysis";
+      const result = useHealItem(fullHeal, monster, 50);
+      expect(result.used).toBe(true);
+      expect(monster.status).toBeNull();
+    });
+
+    it("状態異常がない場合は使えない", () => {
+      const monster = createDummyMonster(30);
+      const result = useHealItem(antidote, monster, 50);
+      expect(result.used).toBe(false);
+    });
+  });
+});

--- a/src/engine/item/bag.ts
+++ b/src/engine/item/bag.ts
@@ -1,0 +1,73 @@
+import type { Bag, BagItem, ItemId, ItemDefinition, MonsterInstance } from "@/types";
+
+/** 空のバッグを作成 */
+export function createBag(): Bag {
+  return { items: [] };
+}
+
+/** アイテムを追加（既存なら個数を加算） */
+export function addItem(bag: Bag, itemId: ItemId, quantity: number = 1): void {
+  const existing = bag.items.find((i) => i.itemId === itemId);
+  if (existing) {
+    existing.quantity += quantity;
+  } else {
+    bag.items.push({ itemId, quantity });
+  }
+}
+
+/** アイテムを消費（個数が0になったら削除） */
+export function removeItem(bag: Bag, itemId: ItemId, quantity: number = 1): boolean {
+  const existing = bag.items.find((i) => i.itemId === itemId);
+  if (!existing || existing.quantity < quantity) return false;
+  existing.quantity -= quantity;
+  if (existing.quantity <= 0) {
+    bag.items.splice(bag.items.indexOf(existing), 1);
+  }
+  return true;
+}
+
+/** アイテムの所持数を取得 */
+export function getItemCount(bag: Bag, itemId: ItemId): number {
+  return bag.items.find((i) => i.itemId === itemId)?.quantity ?? 0;
+}
+
+/** カテゴリでフィルタ */
+export function getItemsByCategory(
+  bag: Bag,
+  category: string,
+  itemResolver: (id: ItemId) => ItemDefinition,
+): BagItem[] {
+  return bag.items.filter((i) => itemResolver(i.itemId).category === category);
+}
+
+/** 回復アイテムの使用 */
+export function useHealItem(
+  item: ItemDefinition,
+  target: MonsterInstance,
+  maxHp: number,
+): { used: boolean; message: string } {
+  if (target.currentHp <= 0) {
+    return { used: false, message: `${target.nickname ?? "モンスター"}は瀕死のため使えない！` };
+  }
+
+  if (item.effect.type === "heal_hp") {
+    if (target.currentHp >= maxHp) {
+      return { used: false, message: "HPは満タンだ！" };
+    }
+    target.currentHp = Math.min(maxHp, target.currentHp + item.effect.amount);
+    return { used: true, message: `HPが${item.effect.amount}回復した！` };
+  }
+
+  if (item.effect.type === "heal_status") {
+    if (target.status === null) {
+      return { used: false, message: "状態異常ではない！" };
+    }
+    if (item.effect.status !== "all" && target.status !== item.effect.status) {
+      return { used: false, message: "このアイテムでは治せない！" };
+    }
+    target.status = null;
+    return { used: true, message: "状態異常が治った！" };
+  }
+
+  return { used: false, message: "このアイテムは使えない！" };
+}

--- a/src/engine/monster/__tests__/evolution.test.ts
+++ b/src/engine/monster/__tests__/evolution.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { checkEvolution, evolve } from "../evolution";
+import type { MonsterInstance, MonsterSpecies } from "@/types";
+
+function createDummyMonster(level: number = 10, currentHp: number = 30): MonsterInstance {
+  return {
+    speciesId: "charmander",
+    level,
+    exp: 1000,
+    ivs: { hp: 15, atk: 15, def: 15, spAtk: 15, spDef: 15, speed: 15 },
+    evs: { hp: 0, atk: 0, def: 0, spAtk: 0, spDef: 0, speed: 0 },
+    currentHp,
+    moves: [{ moveId: "tackle", currentPp: 35 }],
+    status: null,
+  };
+}
+
+const charmander: MonsterSpecies = {
+  id: "charmander",
+  name: "ヒトカゲ",
+  types: ["fire"],
+  baseStats: { hp: 39, atk: 52, def: 43, spAtk: 60, spDef: 50, speed: 65 },
+  learnset: [],
+  evolvesTo: { id: "charmeleon", level: 16 },
+};
+
+const charmeleon: MonsterSpecies = {
+  id: "charmeleon",
+  name: "リザード",
+  types: ["fire"],
+  baseStats: { hp: 58, atk: 64, def: 58, spAtk: 80, spDef: 65, speed: 80 },
+  learnset: [],
+  evolvesTo: { id: "charizard", level: 36 },
+};
+
+const noEvoSpecies: MonsterSpecies = {
+  id: "pikachu",
+  name: "ピカチュウ",
+  types: ["electric"],
+  baseStats: { hp: 35, atk: 55, def: 40, spAtk: 50, spDef: 50, speed: 90 },
+  learnset: [],
+};
+
+describe("進化システム", () => {
+  describe("checkEvolution", () => {
+    it("レベルが進化条件を満たしていれば進化先IDを返す", () => {
+      const monster = createDummyMonster(16);
+      const result = checkEvolution(monster, charmander);
+      expect(result).toBe("charmeleon");
+    });
+
+    it("レベルが足りなければ null を返す", () => {
+      const monster = createDummyMonster(15);
+      const result = checkEvolution(monster, charmander);
+      expect(result).toBeNull();
+    });
+
+    it("進化先がない種族は null を返す", () => {
+      const monster = createDummyMonster(99);
+      const result = checkEvolution(monster, noEvoSpecies);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("evolve", () => {
+    it("speciesIdが更新される", () => {
+      const monster = createDummyMonster(16, 30);
+      evolve(monster, charmander, charmeleon);
+      expect(monster.speciesId).toBe("charmeleon");
+    });
+
+    it("最大HPの増加分が現在HPに加算される", () => {
+      // charmander base HP: 39, charmeleon base HP: 58
+      // レベル16, IV=15, EV=0 での HP:
+      // calcHp(39, 15, 0, 16) = ((2*39+15+0)*16/100) + 16 + 10 = (93*16/100)+26 = 14+26 = 40
+      // calcHp(58, 15, 0, 16) = ((2*58+15+0)*16/100) + 16 + 10 = (131*16/100)+26 = 20+26 = 46
+      // 差分 = 6
+      const monster = createDummyMonster(16, 35);
+      evolve(monster, charmander, charmeleon);
+      expect(monster.currentHp).toBe(41); // 35 + 6
+    });
+
+    it("現在HPが新しい最大HPを超えない", () => {
+      // 新maxHP = 46 の場合、currentHp=45 + 差分6 = 51 → min(46, 51) = 46
+      const monster = createDummyMonster(16, 45);
+      evolve(monster, charmander, charmeleon);
+      expect(monster.currentHp).toBeLessThanOrEqual(46);
+    });
+  });
+});

--- a/src/engine/monster/__tests__/moves.test.ts
+++ b/src/engine/monster/__tests__/moves.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import { getLearnableMoves, learnMove, replaceMove } from "../moves";
+import type { MonsterSpecies, MonsterInstance, MoveDefinition } from "@/types";
+
+function createDummyMonster(moves: { moveId: string; currentPp: number }[] = []): MonsterInstance {
+  return {
+    speciesId: "test",
+    level: 10,
+    exp: 1000,
+    ivs: { hp: 15, atk: 15, def: 15, spAtk: 15, spDef: 15, speed: 15 },
+    evs: { hp: 0, atk: 0, def: 0, spAtk: 0, spDef: 0, speed: 0 },
+    currentHp: 30,
+    moves,
+    status: null,
+  };
+}
+
+const tackledef: MoveDefinition = {
+  id: "tackle",
+  name: "たいあたり",
+  type: "normal",
+  category: "physical",
+  power: 40,
+  accuracy: 100,
+  pp: 35,
+  priority: 0,
+};
+
+const ember: MoveDefinition = {
+  id: "ember",
+  name: "ひのこ",
+  type: "fire",
+  category: "special",
+  power: 40,
+  accuracy: 100,
+  pp: 25,
+  priority: 0,
+};
+
+const scratch: MoveDefinition = {
+  id: "scratch",
+  name: "ひっかく",
+  type: "normal",
+  category: "physical",
+  power: 40,
+  accuracy: 100,
+  pp: 35,
+  priority: 0,
+};
+
+const dummySpecies: MonsterSpecies = {
+  id: "test",
+  name: "テストモン",
+  types: ["fire"],
+  baseStats: { hp: 45, atk: 60, def: 40, spAtk: 70, spDef: 50, speed: 65 },
+  learnset: [
+    { level: 1, moveId: "tackle" },
+    { level: 5, moveId: "ember" },
+    { level: 10, moveId: "scratch" },
+    { level: 15, moveId: "flamethrower" },
+  ],
+};
+
+describe("技管理", () => {
+  describe("getLearnableMoves", () => {
+    it("レベルアップ範囲内の習得可能技を返す", () => {
+      const moves = getLearnableMoves(dummySpecies, 3, 10);
+      expect(moves).toHaveLength(2);
+      expect(moves[0].moveId).toBe("ember");
+      expect(moves[1].moveId).toBe("scratch");
+    });
+
+    it("範囲外の技は返さない", () => {
+      const moves = getLearnableMoves(dummySpecies, 10, 14);
+      expect(moves).toHaveLength(0);
+    });
+
+    it("oldLevelちょうどの技は含まない", () => {
+      const moves = getLearnableMoves(dummySpecies, 5, 10);
+      expect(moves.find((m) => m.moveId === "ember")).toBeUndefined();
+    });
+  });
+
+  describe("learnMove", () => {
+    it("技枠が空いていれば自動で覚える", () => {
+      const monster = createDummyMonster([]);
+      const result = learnMove(monster, "tackle", tackledef);
+      expect(result).toBe("learned");
+      expect(monster.moves).toHaveLength(1);
+      expect(monster.moves[0].moveId).toBe("tackle");
+      expect(monster.moves[0].currentPp).toBe(35);
+    });
+
+    it("既に覚えている技はスキップされる", () => {
+      const monster = createDummyMonster([{ moveId: "tackle", currentPp: 35 }]);
+      const result = learnMove(monster, "tackle", tackledef);
+      expect(result).toBe("learned");
+      expect(monster.moves).toHaveLength(1);
+    });
+
+    it("4枠満杯なら full を返す", () => {
+      const monster = createDummyMonster([
+        { moveId: "tackle", currentPp: 35 },
+        { moveId: "ember", currentPp: 25 },
+        { moveId: "scratch", currentPp: 35 },
+        { moveId: "flamethrower", currentPp: 15 },
+      ]);
+      const result = learnMove(monster, "new-move", ember);
+      expect(result).toBe("full");
+      expect(monster.moves).toHaveLength(4);
+    });
+  });
+
+  describe("replaceMove", () => {
+    it("既存の技を忘れて新しい技を覚える", () => {
+      const monster = createDummyMonster([
+        { moveId: "tackle", currentPp: 35 },
+        { moveId: "ember", currentPp: 25 },
+      ]);
+      const result = replaceMove(monster, 0, "scratch", scratch);
+      expect(result.forgottenMoveId).toBe("tackle");
+      expect(monster.moves[0].moveId).toBe("scratch");
+      expect(monster.moves[0].currentPp).toBe(35);
+    });
+
+    it("無効なスロットインデックスでエラー", () => {
+      const monster = createDummyMonster([{ moveId: "tackle", currentPp: 35 }]);
+      expect(() => replaceMove(monster, -1, "ember", ember)).toThrow("無効な技スロット");
+      expect(() => replaceMove(monster, 5, "ember", ember)).toThrow("無効な技スロット");
+    });
+  });
+});

--- a/src/engine/monster/__tests__/party.test.ts
+++ b/src/engine/monster/__tests__/party.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import {
+  createPartyState,
+  addMonster,
+  swapPartyOrder,
+  depositToBox,
+  withdrawFromBox,
+  aliveCount,
+  healParty,
+} from "../party";
+import type { MonsterInstance, MoveDefinition } from "@/types";
+
+function createDummyMonster(id: string = "test"): MonsterInstance {
+  return {
+    speciesId: id,
+    level: 10,
+    exp: 1000,
+    ivs: { hp: 15, atk: 15, def: 15, spAtk: 15, spDef: 15, speed: 15 },
+    evs: { hp: 0, atk: 0, def: 0, spAtk: 0, spDef: 0, speed: 0 },
+    currentHp: 30,
+    moves: [{ moveId: "tackle", currentPp: 10 }],
+    status: null,
+  };
+}
+
+describe("パーティ管理", () => {
+  it("パーティにモンスターを追加できる（6匹まで）", () => {
+    const state = createPartyState();
+    for (let i = 0; i < 6; i++) {
+      const result = addMonster(state, createDummyMonster(`mon-${i}`));
+      expect(result.destination).toBe("party");
+    }
+    expect(state.party).toHaveLength(6);
+  });
+
+  it("パーティが満杯ならボックスに送られる", () => {
+    const state = createPartyState();
+    for (let i = 0; i < 6; i++) {
+      addMonster(state, createDummyMonster());
+    }
+    const result = addMonster(state, createDummyMonster("7th"));
+    expect(result.destination).toBe("box");
+    expect(result.boxIndex).toBe(0);
+    expect(state.boxes[0]).toHaveLength(1);
+  });
+
+  it("パーティの並び替えができる", () => {
+    const state = createPartyState();
+    addMonster(state, createDummyMonster("a"));
+    addMonster(state, createDummyMonster("b"));
+    addMonster(state, createDummyMonster("c"));
+
+    swapPartyOrder(state, 0, 2);
+    expect(state.party[0].speciesId).toBe("c");
+    expect(state.party[2].speciesId).toBe("a");
+  });
+
+  it("ボックスへ預けられる（パーティ2匹以上時）", () => {
+    const state = createPartyState();
+    addMonster(state, createDummyMonster("a"));
+    addMonster(state, createDummyMonster("b"));
+
+    depositToBox(state, 1, 0);
+    expect(state.party).toHaveLength(1);
+    expect(state.boxes[0]).toHaveLength(1);
+  });
+
+  it("パーティ1匹の時は預けられない", () => {
+    const state = createPartyState();
+    addMonster(state, createDummyMonster());
+
+    expect(() => depositToBox(state, 0, 0)).toThrow("1匹の時は預けられません");
+  });
+
+  it("ボックスから引き出せる", () => {
+    const state = createPartyState();
+    addMonster(state, createDummyMonster("a"));
+    addMonster(state, createDummyMonster("b"));
+    depositToBox(state, 1, 0);
+
+    withdrawFromBox(state, 0, 0);
+    expect(state.party).toHaveLength(2);
+    expect(state.boxes[0]).toHaveLength(0);
+  });
+
+  it("生存数を数える", () => {
+    const state = createPartyState();
+    const m1 = createDummyMonster();
+    m1.currentHp = 30;
+    const m2 = createDummyMonster();
+    m2.currentHp = 0;
+    state.party = [m1, m2];
+
+    expect(aliveCount(state.party)).toBe(1);
+  });
+
+  it("全回復が正しく動作する", () => {
+    const state = createPartyState();
+    const m = createDummyMonster();
+    m.currentHp = 5;
+    m.status = "poison";
+    m.moves[0].currentPp = 0;
+    state.party = [m];
+
+    const moveDef: MoveDefinition = {
+      id: "tackle",
+      name: "たいあたり",
+      type: "normal",
+      category: "physical",
+      power: 40,
+      accuracy: 100,
+      pp: 35,
+      priority: 0,
+    };
+
+    healParty(
+      state.party,
+      () => 50, // maxHp = 50
+      () => moveDef,
+    );
+
+    expect(m.currentHp).toBe(50);
+    expect(m.status).toBeNull();
+    expect(m.moves[0].currentPp).toBe(35);
+  });
+});

--- a/src/engine/monster/evolution.ts
+++ b/src/engine/monster/evolution.ts
@@ -1,0 +1,32 @@
+import type { MonsterInstance, MonsterSpecies } from "@/types";
+import { calcHp } from "./stats";
+
+/**
+ * 進化条件をチェック
+ * @returns 進化先のspeciesId、または null（進化しない場合）
+ */
+export function checkEvolution(monster: MonsterInstance, species: MonsterSpecies): string | null {
+  if (!species.evolvesTo) return null;
+  if (monster.level >= species.evolvesTo.level) {
+    return species.evolvesTo.id;
+  }
+  return null;
+}
+
+/**
+ * 進化を実行する
+ * - speciesIdを更新
+ * - 最大HPの差分を現在HPに加算
+ */
+export function evolve(
+  monster: MonsterInstance,
+  oldSpecies: MonsterSpecies,
+  newSpecies: MonsterSpecies,
+): void {
+  const oldMaxHp = calcHp(oldSpecies.baseStats.hp, monster.ivs.hp, monster.evs.hp, monster.level);
+  const newMaxHp = calcHp(newSpecies.baseStats.hp, monster.ivs.hp, monster.evs.hp, monster.level);
+
+  monster.speciesId = newSpecies.id;
+  // 最大HPの増加分を現在HPに加算
+  monster.currentHp = Math.min(newMaxHp, monster.currentHp + (newMaxHp - oldMaxHp));
+}

--- a/src/engine/monster/moves.ts
+++ b/src/engine/monster/moves.ts
@@ -1,0 +1,55 @@
+import type { MonsterInstance, MoveId, MoveDefinition, MonsterSpecies } from "@/types";
+
+const MAX_MOVES = 4;
+
+/**
+ * レベルアップ時に習得可能な技をチェック
+ * @returns 習得可能な技のリスト
+ */
+export function getLearnableMoves(
+  species: MonsterSpecies,
+  oldLevel: number,
+  newLevel: number,
+): { level: number; moveId: MoveId }[] {
+  return species.learnset.filter((entry) => entry.level > oldLevel && entry.level <= newLevel);
+}
+
+/**
+ * 技を習得する（4枠未満なら自動追加）
+ * @returns "learned" = 覚えた, "full" = 技枠が満杯で選択が必要
+ */
+export function learnMove(
+  monster: MonsterInstance,
+  moveId: MoveId,
+  moveDef: MoveDefinition,
+): "learned" | "full" {
+  // 既に覚えている場合はスキップ
+  if (monster.moves.some((m) => m.moveId === moveId)) {
+    return "learned";
+  }
+
+  if (monster.moves.length < MAX_MOVES) {
+    monster.moves.push({ moveId, currentPp: moveDef.pp });
+    return "learned";
+  }
+
+  return "full";
+}
+
+/**
+ * 既存の技を忘れて新しい技を覚える
+ * @param slotIndex 忘れる技のインデックス (0-3)
+ */
+export function replaceMove(
+  monster: MonsterInstance,
+  slotIndex: number,
+  newMoveId: MoveId,
+  newMoveDef: MoveDefinition,
+): { forgottenMoveId: MoveId } {
+  if (slotIndex < 0 || slotIndex >= monster.moves.length) {
+    throw new Error("無効な技スロット");
+  }
+  const forgotten = monster.moves[slotIndex].moveId;
+  monster.moves[slotIndex] = { moveId: newMoveId, currentPp: newMoveDef.pp };
+  return { forgottenMoveId: forgotten };
+}

--- a/src/engine/monster/party.ts
+++ b/src/engine/monster/party.ts
@@ -1,0 +1,84 @@
+import type { MonsterInstance, MoveDefinition, PartyState } from "@/types";
+
+const MAX_PARTY_SIZE = 6;
+const MAX_BOX_COUNT = 8;
+const MAX_BOX_SIZE = 30;
+
+/** パーティ状態の初期化 */
+export function createPartyState(): PartyState {
+  return {
+    party: [],
+    boxes: Array.from({ length: MAX_BOX_COUNT }, () => []),
+  };
+}
+
+/** パーティにモンスターを追加。満杯ならボックスへ送る */
+export function addMonster(
+  state: PartyState,
+  monster: MonsterInstance,
+): { destination: "party" | "box"; boxIndex?: number } {
+  if (state.party.length < MAX_PARTY_SIZE) {
+    state.party.push(monster);
+    return { destination: "party" };
+  }
+
+  // パーティ満杯 → ボックスへ
+  for (let i = 0; i < state.boxes.length; i++) {
+    if (state.boxes[i].length < MAX_BOX_SIZE) {
+      state.boxes[i].push(monster);
+      return { destination: "box", boxIndex: i };
+    }
+  }
+
+  throw new Error("全てのボックスが満杯です");
+}
+
+/** パーティ内の並び替え */
+export function swapPartyOrder(state: PartyState, indexA: number, indexB: number): void {
+  if (indexA < 0 || indexA >= state.party.length) throw new Error("無効なインデックス");
+  if (indexB < 0 || indexB >= state.party.length) throw new Error("無効なインデックス");
+  [state.party[indexA], state.party[indexB]] = [state.party[indexB], state.party[indexA]];
+}
+
+/** パーティからボックスへ預ける（パーティは最低1匹必要） */
+export function depositToBox(state: PartyState, partyIndex: number, boxIndex: number): void {
+  if (state.party.length <= 1) throw new Error("手持ちが1匹の時は預けられません");
+  if (partyIndex < 0 || partyIndex >= state.party.length) throw new Error("無効なインデックス");
+  if (boxIndex < 0 || boxIndex >= state.boxes.length) throw new Error("無効なボックス番号");
+  if (state.boxes[boxIndex].length >= MAX_BOX_SIZE) throw new Error("ボックスが満杯です");
+
+  const [monster] = state.party.splice(partyIndex, 1);
+  state.boxes[boxIndex].push(monster);
+}
+
+/** ボックスからパーティへ引き出す */
+export function withdrawFromBox(state: PartyState, boxIndex: number, boxSlotIndex: number): void {
+  if (state.party.length >= MAX_PARTY_SIZE) throw new Error("手持ちが満杯です");
+  if (boxIndex < 0 || boxIndex >= state.boxes.length) throw new Error("無効なボックス番号");
+  if (boxSlotIndex < 0 || boxSlotIndex >= state.boxes[boxIndex].length)
+    throw new Error("無効なスロット");
+
+  const [monster] = state.boxes[boxIndex].splice(boxSlotIndex, 1);
+  state.party.push(monster);
+}
+
+/** パーティの生存モンスター数 */
+export function aliveCount(party: MonsterInstance[]): number {
+  return party.filter((m) => m.currentHp > 0).length;
+}
+
+/** パーティ全回復（ポケモンセンター相当） */
+export function healParty(
+  party: MonsterInstance[],
+  maxHpCalc: (monster: MonsterInstance) => number,
+  moveResolver: (moveId: string) => MoveDefinition,
+): void {
+  for (const monster of party) {
+    monster.currentHp = maxHpCalc(monster);
+    monster.status = null;
+    for (const move of monster.moves) {
+      const def = moveResolver(move.moveId);
+      move.currentPp = def.pp;
+    }
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -102,3 +102,46 @@ export type StatusCondition = "poison" | "burn" | "paralysis" | "sleep" | "freez
 
 /** タイプ相性の倍率 */
 export type TypeEffectiveness = 0 | 0.5 | 1 | 2;
+
+/** アイテムカテゴリ */
+export type ItemCategory = "ball" | "medicine" | "battle" | "key";
+
+/** アイテム定義 */
+export interface ItemDefinition {
+  id: ItemId;
+  name: string;
+  description: string;
+  category: ItemCategory;
+  price: number;
+  /** バトル中に使用可能か */
+  usableInBattle: boolean;
+  /** 効果（アイテム種別ごとに異なる） */
+  effect: ItemEffect;
+}
+
+/** アイテム効果 */
+export type ItemEffect =
+  | { type: "heal_hp"; amount: number }
+  | { type: "heal_status"; status: StatusCondition | "all" }
+  | { type: "heal_pp"; amount: number | "all" }
+  | { type: "ball"; catchRateModifier: number }
+  | { type: "none" };
+
+/** バッグ内のアイテム（個数管理） */
+export interface BagItem {
+  itemId: ItemId;
+  quantity: number;
+}
+
+/** プレイヤーのバッグ */
+export interface Bag {
+  items: BagItem[];
+}
+
+/** パーティ + ボックスの管理 */
+export interface PartyState {
+  /** 手持ち（最大6匹） */
+  party: MonsterInstance[];
+  /** ボックス（預かりシステム） */
+  boxes: MonsterInstance[][];
+}


### PR DESCRIPTION
## Summary
- パーティ管理システム（6匹上限、ボックス8個×30匹、並び替え、全回復）
- アイテムバッグシステム（追加/消費/カテゴリフィルタ/回復アイテム使用）
- 技枠管理（4枠制限、レベルアップ習得判定、技入替）
- 進化システム（レベル条件判定、speciesId更新、HP差分加算）
- 型定義追加（ItemDefinition, ItemEffect, ItemCategory, Bag, BagItem, PartyState）
- テスト37件追加（合計79件）

## Closes
- Closes #76 (パーティ管理システム)
- Closes #80 (アイテムバッグ)
- Closes #84 (技枠管理)
- Closes #87 (進化システム)

## Test plan
- [x] 全79テストがパス
- [x] TypeScript型チェック通過
- [x] ESLint通過
- [x] Prettierフォーマット適用済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)