### PR TITLE
feat: 捕獲システム (Epic 5)

### DIFF
--- a/src/engine/capture/__tests__/capture-flow.test.ts
+++ b/src/engine/capture/__tests__/capture-flow.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "vitest";
+import { executeCaptureFlow } from "../capture-flow";
+import { createPartyState, addMonster } from "../../monster/party";
+import type { MonsterInstance } from "@/types";
+
+function createDummyMonster(id: string = "wild"): MonsterInstance {
+  return {
+    speciesId: id,
+    level: 10,
+    exp: 1000,
+    ivs: { hp: 15, atk: 15, def: 15, spAtk: 15, spDef: 15, speed: 15 },
+    evs: { hp: 0, atk: 0, def: 0, spAtk: 0, spDef: 0, speed: 0 },
+    currentHp: 20,
+    moves: [{ moveId: "tackle", currentPp: 35 }],
+    status: null,
+  };
+}
+
+describe("捕獲フロー", () => {
+  it("捕獲成功時にパーティに追加される", () => {
+    const state = createPartyState();
+    addMonster(state, createDummyMonster("ally"));
+    const target = createDummyMonster("wild");
+
+    const result = executeCaptureFlow(
+      {
+        maxHp: 40,
+        currentHp: 20,
+        baseCatchRate: 255,
+        ballModifier: 2,
+        status: null,
+      },
+      target,
+      state,
+      "モンスターボール",
+      () => 0, // 確定捕獲
+    );
+
+    expect(result.catchResult.caught).toBe(true);
+    expect(result.destination).toBe("party");
+    expect(state.party).toHaveLength(2);
+    expect(result.messages).toContain("やった！ 捕まえた！");
+  });
+
+  it("パーティが満杯ならボックスに送られる", () => {
+    const state = createPartyState();
+    for (let i = 0; i < 6; i++) {
+      addMonster(state, createDummyMonster(`ally-${i}`));
+    }
+    const target = createDummyMonster("wild");
+
+    const result = executeCaptureFlow(
+      {
+        maxHp: 40,
+        currentHp: 20,
+        baseCatchRate: 255,
+        ballModifier: 2,
+        status: null,
+      },
+      target,
+      state,
+      "モンスターボール",
+      () => 0,
+    );
+
+    expect(result.catchResult.caught).toBe(true);
+    expect(result.destination).toBe("box");
+    expect(result.boxIndex).toBe(0);
+    expect(state.boxes[0]).toHaveLength(1);
+  });
+
+  it("捕獲失敗時にパーティに追加されない", () => {
+    const state = createPartyState();
+    addMonster(state, createDummyMonster("ally"));
+    const target = createDummyMonster("wild");
+
+    const result = executeCaptureFlow(
+      {
+        maxHp: 100,
+        currentHp: 100,
+        baseCatchRate: 3,
+        ballModifier: 1,
+        status: null,
+      },
+      target,
+      state,
+      "モンスターボール",
+      () => 65535, // 確定失敗
+    );
+
+    expect(result.catchResult.caught).toBe(false);
+    expect(result.destination).toBeUndefined();
+    expect(state.party).toHaveLength(1);
+  });
+
+  it("揺れ0回のメッセージが正しい", () => {
+    const state = createPartyState();
+    const target = createDummyMonster("wild");
+
+    const result = executeCaptureFlow(
+      {
+        maxHp: 100,
+        currentHp: 100,
+        baseCatchRate: 3,
+        ballModifier: 1,
+        status: null,
+      },
+      target,
+      state,
+      "スーパーボール",
+      () => 65535,
+    );
+
+    expect(result.messages[0]).toBe("スーパーボールを投げた！");
+    expect(result.messages).toContain("だめだ！ ボールから出てしまった！");
+  });
+
+  it("揺れ途中失敗のメッセージが正しい", () => {
+    const state = createPartyState();
+    const target = createDummyMonster("wild");
+
+    let callCount = 0;
+    const result = executeCaptureFlow(
+      {
+        maxHp: 100,
+        currentHp: 50,
+        baseCatchRate: 100,
+        ballModifier: 1,
+        status: null,
+      },
+      target,
+      state,
+      "モンスターボール",
+      () => {
+        callCount++;
+        return callCount <= 1 ? 0 : 65535;
+      },
+    );
+
+    expect(result.catchResult.shakeCount).toBe(1);
+    expect(result.messages).toContain("ぽん…");
+    expect(result.messages).toContain("あっ！ もう少しだったのに！");
+  });
+});

--- a/src/engine/capture/__tests__/catch-rate.test.ts
+++ b/src/engine/capture/__tests__/catch-rate.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from "vitest";
+import { calcCatchValue, calcShakeThreshold, attemptCatch } from "../catch-rate";
+
+describe("捕獲率計算", () => {
+  describe("calcCatchValue", () => {
+    it("HP満タンでは低い値になる", () => {
+      const a = calcCatchValue({
+        maxHp: 100,
+        currentHp: 100,
+        baseCatchRate: 45,
+        ballModifier: 1,
+        status: null,
+      });
+      // ((300-200)*45*1*1) / 300 = 4500/300 = 15
+      expect(a).toBe(15);
+    });
+
+    it("HP1で最大に近い値になる", () => {
+      const a = calcCatchValue({
+        maxHp: 100,
+        currentHp: 1,
+        baseCatchRate: 45,
+        ballModifier: 1,
+        status: null,
+      });
+      // ((300-2)*45*1*1) / 300 = 13410/300 = 44.7 → 44
+      expect(a).toBe(44);
+    });
+
+    it("状態異常（sleep）で2倍補正", () => {
+      const aSleep = calcCatchValue({
+        maxHp: 100,
+        currentHp: 50,
+        baseCatchRate: 100,
+        ballModifier: 1,
+        status: "sleep",
+      });
+      // ((300-100)*100*1*2)/300 = 40000/300 = 133.33 → 133
+      expect(aSleep).toBe(133);
+    });
+
+    it("状態異常（poison）で1.5倍補正", () => {
+      const aPoison = calcCatchValue({
+        maxHp: 100,
+        currentHp: 50,
+        baseCatchRate: 100,
+        ballModifier: 1,
+        status: "poison",
+      });
+      // ((300-100)*100*1*1.5)/300 = 30000/300 = 100
+      expect(aPoison).toBe(100);
+    });
+
+    it("ハイパーボール（2倍）で補正される", () => {
+      const a = calcCatchValue({
+        maxHp: 100,
+        currentHp: 50,
+        baseCatchRate: 100,
+        ballModifier: 2,
+        status: null,
+      });
+      // ((300-100)*100*2*1)/300 = 40000/300 = 133
+      expect(a).toBe(133);
+    });
+
+    it("値は1以上255以下に収まる", () => {
+      const aMin = calcCatchValue({
+        maxHp: 1000,
+        currentHp: 1000,
+        baseCatchRate: 1,
+        ballModifier: 1,
+        status: null,
+      });
+      expect(aMin).toBeGreaterThanOrEqual(1);
+
+      const aMax = calcCatchValue({
+        maxHp: 10,
+        currentHp: 1,
+        baseCatchRate: 255,
+        ballModifier: 2,
+        status: "sleep",
+      });
+      expect(aMax).toBeLessThanOrEqual(255);
+    });
+  });
+
+  describe("calcShakeThreshold", () => {
+    it("a=255で確定捕獲（閾値65536）", () => {
+      expect(calcShakeThreshold(255)).toBe(65536);
+    });
+
+    it("a=1で最小の閾値", () => {
+      const threshold = calcShakeThreshold(1);
+      expect(threshold).toBeGreaterThan(0);
+      expect(threshold).toBeLessThan(65536);
+    });
+
+    it("aが大きいほど閾値が高くなる", () => {
+      const low = calcShakeThreshold(10);
+      const high = calcShakeThreshold(100);
+      expect(high).toBeGreaterThan(low);
+    });
+  });
+
+  describe("attemptCatch", () => {
+    it("マスターボール（ballModifier>=255）で確定捕獲", () => {
+      const result = attemptCatch({
+        maxHp: 100,
+        currentHp: 100,
+        baseCatchRate: 3,
+        ballModifier: 255,
+        status: null,
+      });
+      expect(result.caught).toBe(true);
+      expect(result.shakeCount).toBe(3);
+    });
+
+    it("乱数が全て0なら3回揺れて捕獲成功", () => {
+      const result = attemptCatch(
+        {
+          maxHp: 100,
+          currentHp: 50,
+          baseCatchRate: 100,
+          ballModifier: 1,
+          status: null,
+        },
+        () => 0, // 常に最小値
+      );
+      expect(result.caught).toBe(true);
+      expect(result.shakeCount).toBe(3);
+    });
+
+    it("乱数が全て最大なら0回揺れて失敗", () => {
+      const result = attemptCatch(
+        {
+          maxHp: 100,
+          currentHp: 100,
+          baseCatchRate: 3,
+          ballModifier: 1,
+          status: null,
+        },
+        () => 65535, // 常に最大値
+      );
+      expect(result.caught).toBe(false);
+      expect(result.shakeCount).toBe(0);
+    });
+
+    it("途中で失敗すると部分的な揺れ回数を返す", () => {
+      let callCount = 0;
+      const result = attemptCatch(
+        {
+          maxHp: 100,
+          currentHp: 50,
+          baseCatchRate: 100,
+          ballModifier: 1,
+          status: null,
+        },
+        () => {
+          callCount++;
+          return callCount <= 2 ? 0 : 65535; // 2回成功、3回目失敗
+        },
+      );
+      expect(result.caught).toBe(false);
+      expect(result.shakeCount).toBe(2);
+    });
+  });
+});

--- a/src/engine/capture/balls.ts
+++ b/src/engine/capture/balls.ts
@@ -1,0 +1,46 @@
+import type { ItemDefinition } from "@/types";
+
+/**
+ * ボールアイテムの定義 (#63)
+ * 各ボールの捕獲率補正を含む
+ */
+export const BALL_DEFINITIONS = {
+  "monster-ball": {
+    id: "monster-ball",
+    name: "モンスターボール",
+    description: "野生のモンスターを捕まえるためのボール。",
+    category: "ball",
+    price: 200,
+    usableInBattle: true,
+    effect: { type: "ball", catchRateModifier: 1 },
+  },
+  "super-ball": {
+    id: "super-ball",
+    name: "スーパーボール",
+    description: "モンスターボールよりも捕まえやすいボール。",
+    category: "ball",
+    price: 600,
+    usableInBattle: true,
+    effect: { type: "ball", catchRateModifier: 1.5 },
+  },
+  "hyper-ball": {
+    id: "hyper-ball",
+    name: "ハイパーボール",
+    description: "スーパーボールよりもさらに捕まえやすいボール。",
+    category: "ball",
+    price: 1200,
+    usableInBattle: true,
+    effect: { type: "ball", catchRateModifier: 2 },
+  },
+  "master-ball": {
+    id: "master-ball",
+    name: "マスターボール",
+    description: "どんなモンスターでも必ず捕まえられる最高のボール。",
+    category: "ball",
+    price: 0,
+    usableInBattle: true,
+    effect: { type: "ball", catchRateModifier: 255 },
+  },
+} as const satisfies Record<string, ItemDefinition>;
+
+export type BallId = keyof typeof BALL_DEFINITIONS;

--- a/src/engine/capture/capture-flow.ts
+++ b/src/engine/capture/capture-flow.ts
@@ -1,0 +1,71 @@
+import type { MonsterInstance, PartyState } from "@/types";
+import { attemptCatch, type CatchCalcInput, type CatchResult } from "./catch-rate";
+import { addMonster } from "../monster/party";
+
+/**
+ * 捕獲演出フローの結果 (#67)
+ */
+export interface CaptureFlowResult {
+  /** 捕獲判定結果 */
+  catchResult: CatchResult;
+  /** 演出用メッセージ */
+  messages: string[];
+  /** 捕獲成功時の格納先 */
+  destination?: "party" | "box";
+  /** ボックス送りの場合のボックス番号 */
+  boxIndex?: number;
+}
+
+/** 揺れ回数に対応する演出メッセージ */
+function getShakeMessages(ballName: string, shakeCount: number, caught: boolean): string[] {
+  const messages: string[] = [];
+  messages.push(`${ballName}を投げた！`);
+
+  if (shakeCount >= 1) messages.push("ぽん…");
+  if (shakeCount >= 2) messages.push("ぽん…");
+  if (shakeCount >= 3) messages.push("ぽん…");
+
+  if (caught) {
+    messages.push("やった！ 捕まえた！");
+  } else if (shakeCount === 0) {
+    messages.push("だめだ！ ボールから出てしまった！");
+  } else {
+    messages.push("あっ！ もう少しだったのに！");
+  }
+
+  return messages;
+}
+
+/**
+ * 捕獲フローを実行 (#67 + #72)
+ * ボール投擲→揺れ判定→成否→パーティ/ボックス追加
+ */
+export function executeCaptureFlow(
+  input: CatchCalcInput,
+  target: MonsterInstance,
+  partyState: PartyState,
+  ballName: string,
+  random?: () => number,
+): CaptureFlowResult {
+  const catchResult = attemptCatch(input, random);
+  const messages = getShakeMessages(ballName, catchResult.shakeCount, catchResult.caught);
+
+  if (!catchResult.caught) {
+    return { catchResult, messages };
+  }
+
+  // 捕獲成功 → パーティ/ボックスに追加 (#72)
+  const addResult = addMonster(partyState, target);
+  messages.push(
+    addResult.destination === "party"
+      ? `${target.nickname ?? "モンスター"}をパーティに加えた！`
+      : `パーティがいっぱいなので、ボックス${(addResult.boxIndex ?? 0) + 1}に送った！`,
+  );
+
+  return {
+    catchResult,
+    messages,
+    destination: addResult.destination,
+    boxIndex: addResult.boxIndex,
+  };
+}

--- a/src/engine/capture/catch-rate.ts
+++ b/src/engine/capture/catch-rate.ts
@@ -1,0 +1,96 @@
+import type { StatusCondition } from "@/types";
+
+/**
+ * 捕獲率計算エンジン (#59)
+ *
+ * 公式（Gen III+）に準拠:
+ *   a = ((3*maxHp - 2*currentHp) * catchRate * ballModifier) / (3*maxHp) * statusModifier
+ *   揺れ判定: shakeCheck = 1048560 / sqrt(sqrt(16711680 / a))
+ *   3回連続で乱数(0〜65535)がshakeCheck以下なら捕獲成功
+ */
+
+/** 状態異常による捕獲率ボーナス */
+function getStatusModifier(status: StatusCondition | null): number {
+  switch (status) {
+    case "sleep":
+    case "freeze":
+      return 2;
+    case "paralysis":
+    case "poison":
+    case "burn":
+      return 1.5;
+    default:
+      return 1;
+  }
+}
+
+export interface CatchCalcInput {
+  /** モンスターの最大HP */
+  maxHp: number;
+  /** モンスターの現在HP */
+  currentHp: number;
+  /** 種族の捕獲率 (1-255) */
+  baseCatchRate: number;
+  /** ボールの補正倍率 */
+  ballModifier: number;
+  /** 状態異常 */
+  status: StatusCondition | null;
+}
+
+export interface CatchResult {
+  /** 捕獲成功したか */
+  caught: boolean;
+  /** ボールが揺れた回数 (0-3)。3なら捕獲成功 */
+  shakeCount: number;
+}
+
+/**
+ * 捕獲率の「a」値を計算
+ * a = ((3*maxHp - 2*currentHp) * catchRate * ballModifier) / (3*maxHp) * statusModifier
+ */
+export function calcCatchValue(input: CatchCalcInput): number {
+  const { maxHp, currentHp, baseCatchRate, ballModifier, status } = input;
+  const statusMod = getStatusModifier(status);
+
+  const a = ((3 * maxHp - 2 * currentHp) * baseCatchRate * ballModifier * statusMod) / (3 * maxHp);
+
+  return Math.min(255, Math.max(1, Math.floor(a)));
+}
+
+/**
+ * 揺れ判定の閾値を計算
+ * shakeCheck = 1048560 / sqrt(sqrt(16711680 / a))
+ */
+export function calcShakeThreshold(a: number): number {
+  if (a >= 255) return 65536; // 確定捕獲
+  return Math.floor(1048560 / Math.sqrt(Math.sqrt(16711680 / a)));
+}
+
+/**
+ * 捕獲判定を実行
+ * @param input 捕獲計算の入力
+ * @param random 乱数関数 (0-65535の整数を返す)。テスト用にDI可能
+ */
+export function attemptCatch(
+  input: CatchCalcInput,
+  random: () => number = () => Math.floor(Math.random() * 65536),
+): CatchResult {
+  // マスターボール相当（255以上）は確定捕獲
+  if (input.ballModifier >= 255) {
+    return { caught: true, shakeCount: 3 };
+  }
+
+  const a = calcCatchValue(input);
+  const threshold = calcShakeThreshold(a);
+
+  let shakeCount = 0;
+  for (let i = 0; i < 3; i++) {
+    if (random() < threshold) {
+      shakeCount++;
+    } else {
+      break;
+    }
+  }
+
+  return { caught: shakeCount === 3, shakeCount };
+}


### PR DESCRIPTION
## Summary
- 捕獲率計算エンジン（Gen III+公式準拠: HP残量・状態異常・ボール補正）
- ボールアイテム4種定義（モンスター/スーパー/ハイパー/マスターボール）
- 捕獲演出フロー（投擲→揺れ判定→成否メッセージ→パーティ/ボックス格納）
- 乱数DI対応でテスト完全制御可能
- テスト18件追加（合計97件）

## Closes
- Closes #59 (捕獲率計算式)
- Closes #63 (ボールアイテム定義)
- Closes #67 (捕獲演出フロー)
- Closes #72 (捕獲後パーティ追加/ボックス送り)

## Test plan
- [x] 全97テストがパス
- [x] TypeScript型チェック通過
- [x] ESLint通過
- [x] Prettierフォーマット適用済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)