### PR TITLE
feat: マップエンジンシステム (Epic 7 一部)

### DIFF
--- a/src/engine/map/__tests__/encounter.test.ts
+++ b/src/engine/map/__tests__/encounter.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import {
+  shouldEncounter,
+  rollEncounter,
+  rollLevel,
+  generateWildMonster,
+  processEncounter,
+} from "../encounter";
+import type { MapDefinition, EncounterEntry } from "../map-data";
+
+const testEntries: EncounterEntry[] = [
+  { speciesId: "rattata", minLevel: 2, maxLevel: 5, weight: 60 },
+  { speciesId: "pidgey", minLevel: 3, maxLevel: 6, weight: 30 },
+  { speciesId: "pikachu", minLevel: 4, maxLevel: 4, weight: 10 },
+];
+
+describe("エンカウントシステム", () => {
+  describe("shouldEncounter", () => {
+    it("エンカウント率0では発生しない", () => {
+      expect(shouldEncounter(0, () => 0)).toBe(false);
+    });
+
+    it("乱数がエンカウント率未満なら発生する", () => {
+      // encounterRate=20、random()=0.1 → 0.1*100=10 < 20 → true
+      expect(shouldEncounter(20, () => 0.1)).toBe(true);
+    });
+
+    it("乱数がエンカウント率以上なら発生しない", () => {
+      // encounterRate=20、random()=0.5 → 0.5*100=50 >= 20 → false
+      expect(shouldEncounter(20, () => 0.5)).toBe(false);
+    });
+  });
+
+  describe("rollEncounter", () => {
+    it("空テーブルでは null を返す", () => {
+      expect(rollEncounter([], () => 0)).toBeNull();
+    });
+
+    it("重みに基づいて選択される（低い乱数→高重みのエントリ）", () => {
+      // random()=0 → roll=0 → 最初のエントリ (rattata, weight=60)
+      const entry = rollEncounter(testEntries, () => 0);
+      expect(entry!.speciesId).toBe("rattata");
+    });
+
+    it("重みに基づいて選択される（高い乱数→低重みのエントリ）", () => {
+      // random()=0.95 → roll=95 → rattata(60)→35残, pidgey(30)→5残, pikachu(10)→当選
+      const entry = rollEncounter(testEntries, () => 0.95);
+      expect(entry!.speciesId).toBe("pikachu");
+    });
+  });
+
+  describe("rollLevel", () => {
+    it("最小値を返す（乱数=0）", () => {
+      expect(rollLevel(3, 7, () => 0)).toBe(3);
+    });
+
+    it("最大値を返す（乱数=0.99）", () => {
+      expect(rollLevel(3, 7, () => 0.99)).toBe(7);
+    });
+
+    it("同一レベルならそのレベルを返す", () => {
+      expect(rollLevel(5, 5, () => 0.5)).toBe(5);
+    });
+  });
+
+  describe("generateWildMonster", () => {
+    it("出現テーブルからモンスターインスタンスを生成する", () => {
+      const entry = testEntries[0];
+      const monster = generateWildMonster(entry, () => 0.5);
+      expect(monster.speciesId).toBe("rattata");
+      expect(monster.level).toBeGreaterThanOrEqual(2);
+      expect(monster.level).toBeLessThanOrEqual(5);
+      expect(monster.status).toBeNull();
+      expect(monster.evs.hp).toBe(0);
+    });
+
+    it("IVは0-31の範囲で生成される", () => {
+      const monster = generateWildMonster(testEntries[0], () => 0.5);
+      // random()=0.5 → floor(0.5*32) = 16
+      expect(monster.ivs.hp).toBe(16);
+    });
+  });
+
+  describe("processEncounter", () => {
+    const testMap: MapDefinition = {
+      id: "route-1",
+      name: "1番道路",
+      width: 1,
+      height: 1,
+      tiles: [["grass"]],
+      connections: [],
+      encounters: testEntries,
+      encounterRate: 20,
+      npcs: [],
+    };
+
+    it("エンカウントが発生するとモンスターを返す", () => {
+      // random()=0.05 → 5 < 20 → エンカウント発生
+      const monster = processEncounter(testMap, () => 0.05);
+      expect(monster).not.toBeNull();
+      expect(monster!.speciesId).toBe("rattata");
+    });
+
+    it("エンカウントが発生しないとnullを返す", () => {
+      // random()=0.8 → 80 >= 20 → エンカウントなし
+      const monster = processEncounter(testMap, () => 0.8);
+      expect(monster).toBeNull();
+    });
+  });
+});

--- a/src/engine/map/__tests__/healing.test.ts
+++ b/src/engine/map/__tests__/healing.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { needsHealing, useHealingCenter } from "../healing";
+import type { MonsterInstance, MoveDefinition } from "@/types";
+
+function createDummyMonster(hp: number = 30): MonsterInstance {
+  return {
+    speciesId: "test",
+    level: 10,
+    exp: 1000,
+    ivs: { hp: 15, atk: 15, def: 15, spAtk: 15, spDef: 15, speed: 15 },
+    evs: { hp: 0, atk: 0, def: 0, spAtk: 0, spDef: 0, speed: 0 },
+    currentHp: hp,
+    moves: [{ moveId: "tackle", currentPp: 35 }],
+    status: null,
+  };
+}
+
+const moveDef: MoveDefinition = {
+  id: "tackle",
+  name: "たいあたり",
+  type: "normal",
+  category: "physical",
+  power: 40,
+  accuracy: 100,
+  pp: 35,
+  priority: 0,
+};
+
+const maxHpCalc = () => 50;
+const moveResolver = () => moveDef;
+
+describe("回復施設", () => {
+  describe("needsHealing", () => {
+    it("HP減少があれば true", () => {
+      const party = [createDummyMonster(30)];
+      expect(needsHealing(party, maxHpCalc, moveResolver)).toBe(true);
+    });
+
+    it("状態異常があれば true", () => {
+      const m = createDummyMonster(50);
+      m.status = "poison";
+      expect(needsHealing([m], maxHpCalc, moveResolver)).toBe(true);
+    });
+
+    it("PP減少があれば true", () => {
+      const m = createDummyMonster(50);
+      m.moves[0].currentPp = 10;
+      expect(needsHealing([m], maxHpCalc, moveResolver)).toBe(true);
+    });
+
+    it("全員満タンなら false", () => {
+      const m = createDummyMonster(50);
+      expect(needsHealing([m], maxHpCalc, moveResolver)).toBe(false);
+    });
+  });
+
+  describe("useHealingCenter", () => {
+    it("回復が必要な場合、全回復して適切なメッセージ", () => {
+      const m = createDummyMonster(10);
+      m.status = "burn";
+      m.moves[0].currentPp = 0;
+
+      const result = useHealingCenter([m], maxHpCalc, moveResolver);
+      expect(result.wasNeeded).toBe(true);
+      expect(m.currentHp).toBe(50);
+      expect(m.status).toBeNull();
+      expect(m.moves[0].currentPp).toBe(35);
+    });
+
+    it("回復不要の場合でも全回復は実行される", () => {
+      const m = createDummyMonster(50);
+      const result = useHealingCenter([m], maxHpCalc, moveResolver);
+      expect(result.wasNeeded).toBe(false);
+      expect(m.currentHp).toBe(50);
+    });
+  });
+});

--- a/src/engine/map/__tests__/map-data.test.ts
+++ b/src/engine/map/__tests__/map-data.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import {
+  getTileProperties,
+  getTileAt,
+  isWalkable,
+  getConnectionAt,
+  type MapDefinition,
+} from "../map-data";
+
+const testMap: MapDefinition = {
+  id: "test-town",
+  name: "テスト町",
+  width: 3,
+  height: 3,
+  tiles: [
+    ["ground", "grass", "wall"],
+    ["ground", "door", "water"],
+    ["wall", "ground", "ground"],
+  ],
+  connections: [{ targetMapId: "route-1", targetX: 0, targetY: 0, sourceX: 1, sourceY: 1 }],
+  encounters: [],
+  encounterRate: 0,
+  npcs: [],
+};
+
+describe("マップデータ", () => {
+  describe("getTileProperties", () => {
+    it("地面は通行可能・エンカウントなし", () => {
+      const tile = getTileProperties("ground");
+      expect(tile.walkable).toBe(true);
+      expect(tile.encounter).toBe(false);
+    });
+
+    it("草むらは通行可能・エンカウントあり", () => {
+      const tile = getTileProperties("grass");
+      expect(tile.walkable).toBe(true);
+      expect(tile.encounter).toBe(true);
+    });
+
+    it("壁は通行不可", () => {
+      const tile = getTileProperties("wall");
+      expect(tile.walkable).toBe(false);
+    });
+
+    it("水は通行不可", () => {
+      const tile = getTileProperties("water");
+      expect(tile.walkable).toBe(false);
+    });
+  });
+
+  describe("getTileAt", () => {
+    it("マップ範囲内のタイルを取得できる", () => {
+      const tile = getTileAt(testMap, 1, 0);
+      expect(tile).not.toBeNull();
+      expect(tile!.type).toBe("grass");
+    });
+
+    it("マップ範囲外は null を返す", () => {
+      expect(getTileAt(testMap, -1, 0)).toBeNull();
+      expect(getTileAt(testMap, 3, 0)).toBeNull();
+      expect(getTileAt(testMap, 0, -1)).toBeNull();
+      expect(getTileAt(testMap, 0, 3)).toBeNull();
+    });
+  });
+
+  describe("isWalkable", () => {
+    it("地面は通行可能", () => {
+      expect(isWalkable(testMap, 0, 0)).toBe(true);
+    });
+
+    it("壁は通行不可", () => {
+      expect(isWalkable(testMap, 2, 0)).toBe(false);
+    });
+
+    it("範囲外は通行不可", () => {
+      expect(isWalkable(testMap, -1, 0)).toBe(false);
+    });
+  });
+
+  describe("getConnectionAt", () => {
+    it("接続があれば返す", () => {
+      const conn = getConnectionAt(testMap, 1, 1);
+      expect(conn).not.toBeNull();
+      expect(conn!.targetMapId).toBe("route-1");
+    });
+
+    it("接続がなければ null を返す", () => {
+      expect(getConnectionAt(testMap, 0, 0)).toBeNull();
+    });
+  });
+});

--- a/src/engine/map/__tests__/shop.test.ts
+++ b/src/engine/map/__tests__/shop.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { buyItem, sellItem } from "../shop";
+import { createBag, getItemCount } from "../../item/bag";
+import type { ItemDefinition } from "@/types";
+
+const potion: ItemDefinition = {
+  id: "potion",
+  name: "キズぐすり",
+  description: "HPを20回復する",
+  category: "medicine",
+  price: 300,
+  usableInBattle: true,
+  effect: { type: "heal_hp", amount: 20 },
+};
+
+const masterBall: ItemDefinition = {
+  id: "master-ball",
+  name: "マスターボール",
+  description: "絶対に捕まえるボール",
+  category: "ball",
+  price: 0,
+  usableInBattle: true,
+  effect: { type: "ball", catchRateModifier: 255 },
+};
+
+describe("ショップシステム", () => {
+  describe("buyItem", () => {
+    it("所持金が足りれば購入できる", () => {
+      const wallet = { money: 1000 };
+      const bag = createBag();
+      const result = buyItem(wallet, bag, potion, 2);
+      expect(result.success).toBe(true);
+      expect(wallet.money).toBe(400); // 1000 - 300*2
+      expect(getItemCount(bag, "potion")).toBe(2);
+    });
+
+    it("所持金不足では購入できない", () => {
+      const wallet = { money: 100 };
+      const bag = createBag();
+      const result = buyItem(wallet, bag, potion, 1);
+      expect(result.success).toBe(false);
+      expect(wallet.money).toBe(100);
+      expect(getItemCount(bag, "potion")).toBe(0);
+    });
+
+    it("個数0以下では購入できない", () => {
+      const wallet = { money: 1000 };
+      const bag = createBag();
+      const result = buyItem(wallet, bag, potion, 0);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("sellItem", () => {
+    it("アイテムを半額で売却できる", () => {
+      const wallet = { money: 0 };
+      const bag = createBag();
+      bag.items.push({ itemId: "potion", quantity: 3 });
+
+      const result = sellItem(wallet, bag, potion, 2);
+      expect(result.success).toBe(true);
+      expect(wallet.money).toBe(300); // (300/2)*2 = 300
+      expect(getItemCount(bag, "potion")).toBe(1);
+    });
+
+    it("所持していないアイテムは売れない", () => {
+      const wallet = { money: 0 };
+      const bag = createBag();
+      const result = sellItem(wallet, bag, potion, 1);
+      expect(result.success).toBe(false);
+    });
+
+    it("価格0のアイテムは売れない", () => {
+      const wallet = { money: 0 };
+      const bag = createBag();
+      bag.items.push({ itemId: "master-ball", quantity: 1 });
+
+      const result = sellItem(wallet, bag, masterBall, 1);
+      expect(result.success).toBe(false);
+      expect(getItemCount(bag, "master-ball")).toBe(1);
+    });
+  });
+});

--- a/src/engine/map/encounter.ts
+++ b/src/engine/map/encounter.ts
@@ -1,0 +1,107 @@
+import type { MonsterInstance } from "@/types";
+import type { MapDefinition, EncounterEntry } from "./map-data";
+
+/**
+ * エンカウントシステム (#34)
+ * 草むら判定、出現テーブル、出現率による野生モンスター生成
+ */
+
+/**
+ * 草むらでエンカウントが発生するか判定
+ * @param encounterRate マップのエンカウント率 (0-100)
+ * @param random 乱数関数（テスト用DI）
+ */
+export function shouldEncounter(
+  encounterRate: number,
+  random: () => number = Math.random,
+): boolean {
+  if (encounterRate <= 0) return false;
+  return random() * 100 < encounterRate;
+}
+
+/**
+ * 出現テーブルからモンスターを抽選
+ * @param entries 出現テーブル
+ * @param random 乱数関数（テスト用DI）
+ * @returns 選ばれた出現エントリ、またはnull（テーブルが空の場合）
+ */
+export function rollEncounter(
+  entries: EncounterEntry[],
+  random: () => number = Math.random,
+): EncounterEntry | null {
+  if (entries.length === 0) return null;
+
+  const totalWeight = entries.reduce((sum, e) => sum + e.weight, 0);
+  if (totalWeight <= 0) return null;
+
+  let roll = random() * totalWeight;
+  for (const entry of entries) {
+    roll -= entry.weight;
+    if (roll <= 0) return entry;
+  }
+
+  return entries[entries.length - 1];
+}
+
+/**
+ * 出現レベルを決定
+ * @param minLevel 最低レベル
+ * @param maxLevel 最高レベル
+ * @param random 乱数関数（テスト用DI）
+ */
+export function rollLevel(
+  minLevel: number,
+  maxLevel: number,
+  random: () => number = Math.random,
+): number {
+  return minLevel + Math.floor(random() * (maxLevel - minLevel + 1));
+}
+
+/**
+ * 野生モンスターのインスタンスを生成
+ * @param entry 出現テーブルエントリ
+ * @param random 乱数関数（テスト用DI）
+ */
+export function generateWildMonster(
+  entry: EncounterEntry,
+  random: () => number = Math.random,
+): MonsterInstance {
+  const level = rollLevel(entry.minLevel, entry.maxLevel, random);
+
+  // 野生モンスターのIVはランダム (0-31)
+  const rollIv = () => Math.floor(random() * 32);
+
+  return {
+    speciesId: entry.speciesId,
+    level,
+    exp: 0,
+    ivs: {
+      hp: rollIv(),
+      atk: rollIv(),
+      def: rollIv(),
+      spAtk: rollIv(),
+      spDef: rollIv(),
+      speed: rollIv(),
+    },
+    evs: { hp: 0, atk: 0, def: 0, spAtk: 0, spDef: 0, speed: 0 },
+    currentHp: 0, // 後でmaxHpCalcで設定する
+    moves: [], // 後でspeciesのlearnsetから設定する
+    status: null,
+  };
+}
+
+/**
+ * マップ上の草むらタイル踏破時のエンカウント処理
+ * @returns 出現したモンスターのインスタンス、またはnull（エンカウント発生しなかった場合）
+ */
+export function processEncounter(
+  map: MapDefinition,
+  random: () => number = Math.random,
+): MonsterInstance | null {
+  if (!shouldEncounter(map.encounterRate, random)) return null;
+
+  const entry = rollEncounter(map.encounters, random);
+  if (!entry) return null;
+
+  return generateWildMonster(entry, random);
+}

--- a/src/engine/map/healing.ts
+++ b/src/engine/map/healing.ts
@@ -1,0 +1,52 @@
+import type { MonsterInstance, MoveDefinition } from "@/types";
+import { healParty } from "../monster/party";
+
+/**
+ * 回復施設（ポケモンセンター相当）(#50)
+ * パーティのHP・PP・状態異常を全回復する
+ */
+
+export interface HealingResult {
+  /** 回復前に回復が必要だったか */
+  wasNeeded: boolean;
+  message: string;
+}
+
+/**
+ * パーティが回復を必要としているか判定
+ */
+export function needsHealing(
+  party: MonsterInstance[],
+  maxHpCalc: (monster: MonsterInstance) => number,
+  moveResolver: (moveId: string) => MoveDefinition,
+): boolean {
+  return party.some((monster) => {
+    if (monster.currentHp < maxHpCalc(monster)) return true;
+    if (monster.status !== null) return true;
+    return monster.moves.some((move) => {
+      const def = moveResolver(move.moveId);
+      return move.currentPp < def.pp;
+    });
+  });
+}
+
+/**
+ * 回復施設を利用する
+ * パーティ全体を全回復し、結果を返す
+ */
+export function useHealingCenter(
+  party: MonsterInstance[],
+  maxHpCalc: (monster: MonsterInstance) => number,
+  moveResolver: (moveId: string) => MoveDefinition,
+): HealingResult {
+  const wasNeeded = needsHealing(party, maxHpCalc, moveResolver);
+
+  healParty(party, maxHpCalc, moveResolver);
+
+  return {
+    wasNeeded,
+    message: wasNeeded
+      ? "お預かりしたモンスターは元気になりましたよ！"
+      : "またいつでもお越しください！",
+  };
+}

--- a/src/engine/map/map-data.ts
+++ b/src/engine/map/map-data.ts
@@ -1,0 +1,98 @@
+import type { MapId, MonsterId } from "@/types";
+
+/** タイルの種類 */
+export type TileType = "ground" | "wall" | "grass" | "water" | "ledge" | "door" | "sign";
+
+/** タイル1マスのデータ */
+export interface Tile {
+  type: TileType;
+  /** 通行可能か */
+  walkable: boolean;
+  /** エンカウント発生するか */
+  encounter: boolean;
+}
+
+/** マップ接続情報 */
+export interface MapConnection {
+  /** 接続先マップID */
+  targetMapId: MapId;
+  /** 接続先座標 */
+  targetX: number;
+  targetY: number;
+  /** 接続元の座標範囲（ドアや出入口の位置） */
+  sourceX: number;
+  sourceY: number;
+}
+
+/** 野生モンスター出現テーブルのエントリ */
+export interface EncounterEntry {
+  speciesId: MonsterId;
+  /** 出現レベル範囲 */
+  minLevel: number;
+  maxLevel: number;
+  /** 出現率の重み（合計100） */
+  weight: number;
+}
+
+/** NPC定義 */
+export interface NpcDefinition {
+  id: string;
+  name: string;
+  x: number;
+  y: number;
+  /** 会話テキスト（配列で複数ページ） */
+  dialogue: string[];
+  /** トレーナーとして戦闘するか */
+  isTrainer: boolean;
+}
+
+/** マップ定義 */
+export interface MapDefinition {
+  id: MapId;
+  name: string;
+  width: number;
+  height: number;
+  /** タイルデータ（height × width の2次元配列） */
+  tiles: TileType[][];
+  /** マップ間接続 */
+  connections: MapConnection[];
+  /** 野生モンスター出現テーブル */
+  encounters: EncounterEntry[];
+  /** エンカウント発生率（0-100、草むらに入った時の判定確率） */
+  encounterRate: number;
+  /** NPC一覧 */
+  npcs: NpcDefinition[];
+}
+
+/** タイルの基本属性マップ */
+const TILE_PROPERTIES: Record<TileType, Pick<Tile, "walkable" | "encounter">> = {
+  ground: { walkable: true, encounter: false },
+  wall: { walkable: false, encounter: false },
+  grass: { walkable: true, encounter: true },
+  water: { walkable: false, encounter: false },
+  ledge: { walkable: true, encounter: false },
+  door: { walkable: true, encounter: false },
+  sign: { walkable: false, encounter: false },
+};
+
+/** タイル種別から属性を取得 */
+export function getTileProperties(type: TileType): Tile {
+  return { type, ...TILE_PROPERTIES[type] };
+}
+
+/** マップ上の指定座標のタイルを取得 */
+export function getTileAt(map: MapDefinition, x: number, y: number): Tile | null {
+  if (x < 0 || x >= map.width || y < 0 || y >= map.height) return null;
+  return getTileProperties(map.tiles[y][x]);
+}
+
+/** 指定座標が通行可能か判定 */
+export function isWalkable(map: MapDefinition, x: number, y: number): boolean {
+  const tile = getTileAt(map, x, y);
+  return tile !== null && tile.walkable;
+}
+
+/** 指定座標にあるマップ接続を取得 */
+export function getConnectionAt(map: MapDefinition, x: number, y: number): MapConnection | null {
+  return map.connections.find((c) => c.sourceX === x && c.sourceY === y) ?? null;
+}

--- a/src/engine/map/shop.ts
+++ b/src/engine/map/shop.ts
@@ -1,0 +1,85 @@
+import type { Bag, ItemId, ItemDefinition } from "@/types";
+import { addItem, removeItem, getItemCount } from "../item/bag";
+
+/**
+ * ショップシステム (#45)
+ * アイテムの購入・売却
+ */
+
+/** プレイヤーの所持金 */
+export interface Wallet {
+  money: number;
+}
+
+/** ショップの商品ラインナップ */
+export interface ShopInventory {
+  /** 販売アイテムのID一覧 */
+  items: ItemId[];
+}
+
+/** 購入結果 */
+export interface TransactionResult {
+  success: boolean;
+  message: string;
+}
+
+/**
+ * アイテムを購入
+ * @param wallet プレイヤーの財布
+ * @param bag プレイヤーのバッグ
+ * @param itemDef 購入するアイテムの定義
+ * @param quantity 個数
+ */
+export function buyItem(
+  wallet: Wallet,
+  bag: Bag,
+  itemDef: ItemDefinition,
+  quantity: number = 1,
+): TransactionResult {
+  if (quantity <= 0) return { success: false, message: "個数が無効です" };
+
+  const totalCost = itemDef.price * quantity;
+  if (wallet.money < totalCost) {
+    return { success: false, message: "お金が足りません！" };
+  }
+
+  wallet.money -= totalCost;
+  addItem(bag, itemDef.id, quantity);
+  return {
+    success: true,
+    message: `${itemDef.name}を${quantity}個買った！`,
+  };
+}
+
+/**
+ * アイテムを売却（購入価格の半額）
+ * @param wallet プレイヤーの財布
+ * @param bag プレイヤーのバッグ
+ * @param itemDef 売却するアイテムの定義
+ * @param quantity 個数
+ */
+export function sellItem(
+  wallet: Wallet,
+  bag: Bag,
+  itemDef: ItemDefinition,
+  quantity: number = 1,
+): TransactionResult {
+  if (quantity <= 0) return { success: false, message: "個数が無効です" };
+
+  const owned = getItemCount(bag, itemDef.id);
+  if (owned < quantity) {
+    return { success: false, message: "そのアイテムは持っていません！" };
+  }
+
+  if (itemDef.price === 0) {
+    return { success: false, message: "このアイテムは売れません！" };
+  }
+
+  const sellPrice = Math.floor(itemDef.price / 2) * quantity;
+  removeItem(bag, itemDef.id, quantity);
+  wallet.money += sellPrice;
+  return {
+    success: true,
+    message: `${itemDef.name}を${quantity}個売った！ ${sellPrice}円を手に入れた！`,
+  };
+}


### PR DESCRIPTION
## Summary
- マップデータ構造設計（タイル属性、グリッド座標、マップ接続情報、NPC定義）
- エンカウントシステム（草むら判定、重み付き出現テーブル抽選、レベル範囲内ランダム決定、野生モンスター生成）
- ショップシステム（購入/売却、所持金管理、半額売却、価格0売却不可）
- 回復施設（全回復、HP/PP/状態異常の回復判定）
- 全ロジック乱数DI対応
- テスト36件追加（合計133件）

## Closes
- Closes #26 (マップデータ構造の設計)
- Closes #34 (エンカウントシステム)
- Closes #45 (ショップシステム)
- Closes #50 (回復施設)

## Note
Epic 7 のUI関連Issue (#28, #31, #37, #41) はフロントエンド実装フェーズで対応予定。

## Test plan
- [x] 全133テストがパス
- [x] TypeScript型チェック通過
- [x] ESLint通過
- [x] Prettierフォーマット適用済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)