### PR TITLE
feat: ゲームUI基盤 — タイトル・スターター選択・メッセージシステム (Epic 8 一部)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,10 @@
+import { GameProvider } from "@/components/GameProvider";
+import { Game } from "@/components/Game";
+
 export default function Home() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-black font-sans">
-      <main className="flex flex-col items-center gap-8 text-center">
-        <h1 className="text-5xl font-bold tracking-tight text-white">Pokemon Game</h1>
-        <p className="text-lg text-zinc-400">開発中...</p>
-      </main>
-    </div>
+    <GameProvider>
+      <Game />
+    </GameProvider>
   );
 }

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useGameState, useGameDispatch } from "./GameProvider";
+import { TitleScreen } from "./screens/TitleScreen";
+import { StarterSelect, type StarterOption } from "./screens/StarterSelect";
+import type { MonsterInstance } from "@/types";
+
+/** 仮のスターター定義（将来はデータマスターから読む） */
+const STARTERS: StarterOption[] = [
+  {
+    speciesId: "fire-starter",
+    name: "ヒノコグマ",
+    type: "fire",
+    description: "小さな炎を操る子グマのモンスター。情熱的で勇敢な性格。",
+  },
+  {
+    speciesId: "water-starter",
+    name: "ミズガメ",
+    type: "water",
+    description: "背中の甲羅から水を噴射するカメのモンスター。穏やかで忍耐強い。",
+  },
+  {
+    speciesId: "grass-starter",
+    name: "ハナリス",
+    type: "grass",
+    description: "花の蕾を尻尾につけたリスのモンスター。好奇心旺盛で元気いっぱい。",
+  },
+];
+
+function createStarterInstance(speciesId: string): MonsterInstance {
+  return {
+    speciesId,
+    level: 5,
+    exp: 0,
+    ivs: { hp: 20, atk: 20, def: 20, spAtk: 20, spDef: 20, speed: 20 },
+    evs: { hp: 0, atk: 0, def: 0, spAtk: 0, spDef: 0, speed: 0 },
+    currentHp: 20,
+    moves: [{ moveId: "tackle", currentPp: 35 }],
+    status: null,
+  };
+}
+
+export function Game() {
+  const state = useGameState();
+  const dispatch = useGameDispatch();
+
+  switch (state.screen) {
+    case "title":
+      return (
+        <TitleScreen onNewGame={(name) => dispatch({ type: "START_NEW_GAME", playerName: name })} />
+      );
+
+    case "starter_select":
+      return (
+        <StarterSelect
+          starters={STARTERS}
+          onSelect={(speciesId) =>
+            dispatch({ type: "SET_STARTER", monster: createStarterInstance(speciesId) })
+          }
+        />
+      );
+
+    case "overworld":
+      return (
+        <div className="flex min-h-screen items-center justify-center bg-gray-950">
+          <div className="text-center">
+            <p className="font-mono text-lg text-white">{state.player?.name}の冒険が始まった！</p>
+            <p className="mt-2 font-mono text-gray-400">
+              パーティ: {state.player?.partyState.party.map((m) => m.speciesId).join(", ")}
+            </p>
+            <p className="mt-4 font-mono text-sm text-gray-600">（オーバーワールドは開発中...）</p>
+          </div>
+        </div>
+      );
+
+    default:
+      return (
+        <div className="flex min-h-screen items-center justify-center bg-black">
+          <p className="font-mono text-white">画面: {state.screen}（開発中）</p>
+        </div>
+      );
+  }
+}

--- a/src/components/GameProvider.tsx
+++ b/src/components/GameProvider.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { createContext, useContext, useReducer, type Dispatch, type ReactNode } from "react";
+import {
+  createInitialGameState,
+  gameReducer,
+  type GameState,
+  type GameAction,
+} from "@/engine/state/game-state";
+
+const GameStateContext = createContext<GameState | null>(null);
+const GameDispatchContext = createContext<Dispatch<GameAction> | null>(null);
+
+export function GameProvider({ children }: { children: ReactNode }) {
+  const [state, dispatch] = useReducer(gameReducer, undefined, createInitialGameState);
+
+  return (
+    <GameStateContext value={state}>
+      <GameDispatchContext value={dispatch}>{children}</GameDispatchContext>
+    </GameStateContext>
+  );
+}
+
+export function useGameState(): GameState {
+  const state = useContext(GameStateContext);
+  if (!state) throw new Error("useGameState must be used within GameProvider");
+  return state;
+}
+
+export function useGameDispatch(): Dispatch<GameAction> {
+  const dispatch = useContext(GameDispatchContext);
+  if (!dispatch) throw new Error("useGameDispatch must be used within GameProvider");
+  return dispatch;
+}

--- a/src/components/screens/StarterSelect.tsx
+++ b/src/components/screens/StarterSelect.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useState } from "react";
+
+/**
+ * スターター選択画面 (#58)
+ * 御三家から1匹を選ぶ
+ */
+
+export interface StarterOption {
+  speciesId: string;
+  name: string;
+  type: string;
+  description: string;
+}
+
+export interface StarterSelectProps {
+  starters: StarterOption[];
+  onSelect: (speciesId: string) => void;
+  professorName?: string;
+}
+
+const TYPE_COLORS: Record<string, string> = {
+  fire: "text-orange-400 border-orange-400",
+  water: "text-blue-400 border-blue-400",
+  grass: "text-green-400 border-green-400",
+  electric: "text-yellow-400 border-yellow-400",
+  normal: "text-gray-300 border-gray-300",
+};
+
+export function StarterSelect({ starters, onSelect, professorName = "博士" }: StarterSelectProps) {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [confirming, setConfirming] = useState(false);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (confirming) {
+      if (e.key === "Enter" || e.key === "z") {
+        onSelect(starters[selectedIndex].speciesId);
+      }
+      if (e.key === "Escape" || e.key === "x") {
+        setConfirming(false);
+      }
+      return;
+    }
+
+    if (e.key === "ArrowLeft" || e.key === "a") {
+      setSelectedIndex((prev) => (prev - 1 + starters.length) % starters.length);
+    }
+    if (e.key === "ArrowRight" || e.key === "d") {
+      setSelectedIndex((prev) => (prev + 1) % starters.length);
+    }
+    if (e.key === "Enter" || e.key === "z") {
+      setConfirming(true);
+    }
+  };
+
+  const selected = starters[selectedIndex];
+
+  return (
+    <div
+      className="flex min-h-screen flex-col items-center justify-center bg-gray-950"
+      onKeyDown={handleKeyDown}
+      tabIndex={0}
+    >
+      {/* 博士のセリフ */}
+      <div className="mb-8 max-w-lg rounded-lg bg-gray-900/80 px-6 py-4">
+        <p className="font-mono text-lg text-white">
+          {confirming
+            ? `${selected.name}でよいかな？`
+            : `${professorName}「この3匹から1匹を選ぶのじゃ！」`}
+        </p>
+      </div>
+
+      {/* スターター選択カード */}
+      <div className="flex gap-6">
+        {starters.map((starter, i) => {
+          const isSelected = i === selectedIndex;
+          const colorClass = TYPE_COLORS[starter.type] ?? TYPE_COLORS.normal;
+
+          return (
+            <button
+              key={starter.speciesId}
+              className={`flex w-40 flex-col items-center rounded-xl border-2 p-4 transition-all ${
+                isSelected
+                  ? `${colorClass} scale-110 bg-white/10 shadow-lg`
+                  : "border-gray-700 bg-gray-900 text-gray-500 hover:border-gray-500"
+              }`}
+              onClick={() => {
+                setSelectedIndex(i);
+                if (isSelected) setConfirming(true);
+              }}
+            >
+              {/* モンスターアイコン（プレースホルダー） */}
+              <div
+                className={`mb-3 flex h-20 w-20 items-center justify-center rounded-full border-2 text-3xl ${
+                  isSelected ? colorClass : "border-gray-600"
+                }`}
+              >
+                {starter.type === "fire" ? "🔥" : starter.type === "water" ? "💧" : "🌿"}
+              </div>
+
+              <span
+                className={`font-mono text-lg font-bold ${isSelected ? "text-white" : "text-gray-400"}`}
+              >
+                {starter.name}
+              </span>
+              <span
+                className={`mt-1 font-mono text-xs uppercase ${isSelected ? colorClass.split(" ")[0] : "text-gray-600"}`}
+              >
+                {starter.type}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* 選択中のモンスターの説明 */}
+      <div className="mt-8 max-w-md text-center">
+        <p className="font-mono text-gray-300">{selected?.description}</p>
+      </div>
+
+      {/* 確認ダイアログ */}
+      {confirming && (
+        <div className="mt-6 flex gap-4">
+          <button
+            className="rounded bg-emerald-600 px-6 py-2 font-mono text-white hover:bg-emerald-500"
+            onClick={() => onSelect(starters[selectedIndex].speciesId)}
+          >
+            はい
+          </button>
+          <button
+            className="rounded bg-gray-700 px-6 py-2 font-mono text-gray-300 hover:bg-gray-600"
+            onClick={() => setConfirming(false)}
+          >
+            いいえ
+          </button>
+        </div>
+      )}
+
+      {/* 操作ガイド */}
+      {!confirming && (
+        <p className="mt-8 font-mono text-xs text-gray-600">← → で選択 / Enter で決定</p>
+      )}
+    </div>
+  );
+}

--- a/src/components/screens/TitleScreen.tsx
+++ b/src/components/screens/TitleScreen.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState } from "react";
+
+/**
+ * タイトル画面 (#54)
+ * ゲーム開始フロー
+ */
+
+export interface TitleScreenProps {
+  onNewGame: (playerName: string) => void;
+  onContinue?: () => void;
+  hasSaveData?: boolean;
+}
+
+export function TitleScreen({ onNewGame, onContinue, hasSaveData = false }: TitleScreenProps) {
+  const [showNameInput, setShowNameInput] = useState(false);
+  const [playerName, setPlayerName] = useState("");
+  const [selectedOption, setSelectedOption] = useState(0);
+
+  const options = [
+    ...(hasSaveData ? [{ label: "つづきから", action: () => onContinue?.() }] : []),
+    { label: "はじめから", action: () => setShowNameInput(true) },
+  ];
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (showNameInput) return;
+    if (e.key === "ArrowUp" || e.key === "w") {
+      setSelectedOption((prev) => (prev - 1 + options.length) % options.length);
+    }
+    if (e.key === "ArrowDown" || e.key === "s") {
+      setSelectedOption((prev) => (prev + 1) % options.length);
+    }
+    if (e.key === "Enter" || e.key === "z" || e.key === " ") {
+      options[selectedOption].action();
+    }
+  };
+
+  const handleNameSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = playerName.trim();
+    if (trimmed.length > 0 && trimmed.length <= 8) {
+      onNewGame(trimmed);
+    }
+  };
+
+  return (
+    <div
+      className="flex min-h-screen flex-col items-center justify-center bg-black"
+      onKeyDown={handleKeyDown}
+      tabIndex={0}
+    >
+      {/* タイトルロゴ */}
+      <div className="mb-16">
+        <h1 className="text-6xl font-bold tracking-wider text-white drop-shadow-lg">
+          MONSTER
+          <br />
+          <span className="text-4xl text-emerald-400">CHRONICLE</span>
+        </h1>
+      </div>
+
+      {!showNameInput ? (
+        /* メニュー */
+        <div className="space-y-2">
+          {options.map((opt, i) => (
+            <button
+              key={opt.label}
+              className={`block w-48 rounded px-4 py-2 text-center font-mono text-lg transition-colors ${
+                i === selectedOption ? "bg-white/20 text-white" : "text-gray-400 hover:text-white"
+              }`}
+              onClick={() => opt.action()}
+              onMouseEnter={() => setSelectedOption(i)}
+            >
+              {i === selectedOption ? "▶ " : "  "}
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      ) : (
+        /* 名前入力 */
+        <form onSubmit={handleNameSubmit} className="flex flex-col items-center gap-4">
+          <p className="font-mono text-lg text-white">あなたの名前は？</p>
+          <input
+            type="text"
+            value={playerName}
+            onChange={(e) => setPlayerName(e.target.value)}
+            maxLength={8}
+            className="w-48 rounded border-2 border-white/30 bg-gray-900 px-4 py-2 text-center font-mono text-lg text-white focus:border-emerald-400 focus:outline-none"
+            autoFocus
+            placeholder="なまえ"
+          />
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => setShowNameInput(false)}
+              className="rounded px-4 py-1 font-mono text-gray-400 hover:text-white"
+            >
+              もどる
+            </button>
+            <button
+              type="submit"
+              disabled={playerName.trim().length === 0}
+              className="rounded bg-emerald-600 px-4 py-1 font-mono text-white hover:bg-emerald-500 disabled:opacity-50"
+            >
+              けってい
+            </button>
+          </div>
+        </form>
+      )}
+
+      {/* Press Start */}
+      {!showNameInput && (
+        <p className="mt-16 animate-pulse font-mono text-sm text-gray-500">Press Enter to start</p>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/MessageWindow.tsx
+++ b/src/components/ui/MessageWindow.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+/**
+ * テキストメッセージシステム (#81)
+ * タイプライター演出、選択肢表示、ページ送り
+ */
+
+export interface MessageWindowProps {
+  /** 表示するメッセージ（配列で複数ページ） */
+  messages: string[];
+  /** 全メッセージ表示完了時のコールバック */
+  onComplete?: () => void;
+  /** 1文字あたりの表示間隔（ms） */
+  charDelay?: number;
+  /** 選択肢（最後のメッセージの後に表示） */
+  choices?: { label: string; value: string }[];
+  /** 選択肢が選ばれた時のコールバック */
+  onChoice?: (value: string) => void;
+}
+
+export function MessageWindow({
+  messages,
+  onComplete,
+  charDelay = 30,
+  choices,
+  onChoice,
+}: MessageWindowProps) {
+  const [pageIndex, setPageIndex] = useState(0);
+  const [displayedText, setDisplayedText] = useState("");
+  const [isTyping, setIsTyping] = useState(true);
+  const [showChoices, setShowChoices] = useState(false);
+  const [selectedChoice, setSelectedChoice] = useState(0);
+
+  const currentMessage = messages[pageIndex] ?? "";
+  const isLastPage = pageIndex >= messages.length - 1;
+
+  // タイプライター効果
+  useEffect(() => {
+    setDisplayedText("");
+    setIsTyping(true);
+    setShowChoices(false);
+
+    let charIndex = 0;
+    const timer = setInterval(() => {
+      charIndex++;
+      if (charIndex >= currentMessage.length) {
+        setDisplayedText(currentMessage);
+        setIsTyping(false);
+        clearInterval(timer);
+        if (isLastPage && choices && choices.length > 0) {
+          setShowChoices(true);
+        }
+      } else {
+        setDisplayedText(currentMessage.slice(0, charIndex));
+      }
+    }, charDelay);
+
+    return () => clearInterval(timer);
+  }, [pageIndex, currentMessage, charDelay, isLastPage, choices]);
+
+  const handleAdvance = useCallback(() => {
+    if (isTyping) {
+      // タイプ中にクリック→即時全文表示
+      setDisplayedText(currentMessage);
+      setIsTyping(false);
+      if (isLastPage && choices && choices.length > 0) {
+        setShowChoices(true);
+      }
+      return;
+    }
+
+    if (showChoices) return; // 選択肢表示中は進まない
+
+    if (!isLastPage) {
+      setPageIndex((prev) => prev + 1);
+    } else {
+      onComplete?.();
+    }
+  }, [isTyping, isLastPage, showChoices, currentMessage, choices, onComplete]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === " " || e.key === "Enter" || e.key === "z") {
+        if (showChoices && choices) {
+          onChoice?.(choices[selectedChoice].value);
+          return;
+        }
+        handleAdvance();
+      }
+      if (showChoices && choices) {
+        if (e.key === "ArrowUp" || e.key === "w") {
+          setSelectedChoice((prev) => (prev - 1 + choices.length) % choices.length);
+        }
+        if (e.key === "ArrowDown" || e.key === "s") {
+          setSelectedChoice((prev) => (prev + 1) % choices.length);
+        }
+      }
+    },
+    [showChoices, choices, selectedChoice, onChoice, handleAdvance],
+  );
+
+  return (
+    <div
+      className="fixed bottom-0 left-0 right-0 z-50 mx-auto max-w-2xl p-4"
+      onKeyDown={handleKeyDown}
+      onClick={handleAdvance}
+      tabIndex={0}
+      role="dialog"
+      aria-label="メッセージウィンドウ"
+    >
+      <div className="rounded-lg border-4 border-white/30 bg-gray-900/95 p-4 shadow-lg">
+        <p className="min-h-[3rem] font-mono text-lg leading-relaxed text-white">
+          {displayedText}
+          {isTyping && <span className="animate-pulse">▌</span>}
+        </p>
+
+        {!isTyping && !showChoices && (
+          <div className="mt-2 flex justify-end">
+            <span className="animate-bounce text-white">▼</span>
+          </div>
+        )}
+
+        {showChoices && choices && (
+          <div className="mt-3 space-y-1">
+            {choices.map((choice, i) => (
+              <button
+                key={choice.value}
+                className={`block w-full rounded px-3 py-1 text-left font-mono text-white transition-colors ${
+                  i === selectedChoice ? "bg-white/20" : "bg-transparent hover:bg-white/10"
+                }`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onChoice?.(choice.value);
+                }}
+              >
+                {i === selectedChoice ? "▶ " : "  "}
+                {choice.label}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/engine/state/__tests__/game-state.test.ts
+++ b/src/engine/state/__tests__/game-state.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { createInitialGameState, createNewPlayerState, gameReducer } from "../game-state";
+import type { MonsterInstance } from "@/types";
+
+function createDummyMonster(): MonsterInstance {
+  return {
+    speciesId: "fire-starter",
+    level: 5,
+    exp: 0,
+    ivs: { hp: 20, atk: 20, def: 20, spAtk: 20, spDef: 20, speed: 20 },
+    evs: { hp: 0, atk: 0, def: 0, spAtk: 0, spDef: 0, speed: 0 },
+    currentHp: 20,
+    moves: [{ moveId: "tackle", currentPp: 35 }],
+    status: null,
+  };
+}
+
+describe("ゲーム状態管理", () => {
+  it("初期状態はタイトル画面", () => {
+    const state = createInitialGameState();
+    expect(state.screen).toBe("title");
+    expect(state.player).toBeNull();
+  });
+
+  it("新規プレイヤー状態が正しく作成される", () => {
+    const player = createNewPlayerState("サトシ");
+    expect(player.name).toBe("サトシ");
+    expect(player.money).toBe(3000);
+    expect(player.partyState.party).toHaveLength(0);
+    expect(player.bag.items).toHaveLength(0);
+  });
+
+  describe("gameReducer", () => {
+    it("START_NEW_GAME でスターター選択画面に遷移", () => {
+      const state = createInitialGameState();
+      const next = gameReducer(state, { type: "START_NEW_GAME", playerName: "サトシ" });
+      expect(next.screen).toBe("starter_select");
+      expect(next.player).not.toBeNull();
+      expect(next.player!.name).toBe("サトシ");
+    });
+
+    it("CHANGE_SCREEN で画面を変更", () => {
+      const state = createInitialGameState();
+      const next = gameReducer(state, { type: "CHANGE_SCREEN", screen: "menu" });
+      expect(next.screen).toBe("menu");
+    });
+
+    it("SET_STARTER でスターターがパーティに追加されオーバーワールドに遷移", () => {
+      let state = createInitialGameState();
+      state = gameReducer(state, { type: "START_NEW_GAME", playerName: "サトシ" });
+
+      const monster = createDummyMonster();
+      state = gameReducer(state, { type: "SET_STARTER", monster });
+
+      expect(state.screen).toBe("overworld");
+      expect(state.player!.partyState.party).toHaveLength(1);
+      expect(state.player!.partyState.party[0].speciesId).toBe("fire-starter");
+      expect(state.player!.pokedexSeen.has("fire-starter")).toBe(true);
+      expect(state.player!.pokedexCaught.has("fire-starter")).toBe(true);
+    });
+
+    it("SET_STORY_FLAG でフラグを設定", () => {
+      const state = createInitialGameState();
+      const next = gameReducer(state, {
+        type: "SET_STORY_FLAG",
+        flag: "gym1_cleared",
+        value: true,
+      });
+      expect(next.storyFlags.gym1_cleared).toBe(true);
+    });
+
+    it("playerがnullの時SET_STARTERは無視される", () => {
+      const state = createInitialGameState();
+      const next = gameReducer(state, { type: "SET_STARTER", monster: createDummyMonster() });
+      expect(next.screen).toBe("title"); // 変更なし
+    });
+  });
+});

--- a/src/engine/state/game-state.ts
+++ b/src/engine/state/game-state.ts
@@ -1,0 +1,119 @@
+import type { MonsterInstance, Bag, PartyState } from "@/types";
+
+/**
+ * ゲーム全体の状態定義
+ */
+
+export type ScreenId =
+  | "title"
+  | "starter_select"
+  | "overworld"
+  | "battle"
+  | "party"
+  | "bag"
+  | "pokedex"
+  | "menu"
+  | "shop"
+  | "healing_center"
+  | "dialogue";
+
+export interface PlayerState {
+  name: string;
+  money: number;
+  badges: string[];
+  partyState: PartyState;
+  bag: Bag;
+  /** 図鑑に登録済みのモンスターID */
+  pokedexSeen: Set<string>;
+  pokedexCaught: Set<string>;
+}
+
+export interface OverworldState {
+  currentMapId: string;
+  playerX: number;
+  playerY: number;
+  direction: "up" | "down" | "left" | "right";
+}
+
+export interface GameState {
+  screen: ScreenId;
+  player: PlayerState | null;
+  overworld: OverworldState | null;
+  /** ストーリーフラグ */
+  storyFlags: Record<string, boolean>;
+}
+
+/** 初期ゲーム状態 */
+export function createInitialGameState(): GameState {
+  return {
+    screen: "title",
+    player: null,
+    overworld: null,
+    storyFlags: {},
+  };
+}
+
+/** 新規ゲーム開始時のプレイヤー初期状態 */
+export function createNewPlayerState(name: string): PlayerState {
+  return {
+    name,
+    money: 3000,
+    badges: [],
+    partyState: {
+      party: [],
+      boxes: Array.from({ length: 8 }, () => []),
+    },
+    bag: { items: [] },
+    pokedexSeen: new Set(),
+    pokedexCaught: new Set(),
+  };
+}
+
+export type GameAction =
+  | { type: "START_NEW_GAME"; playerName: string }
+  | { type: "CHANGE_SCREEN"; screen: ScreenId }
+  | { type: "SET_STARTER"; monster: MonsterInstance }
+  | { type: "UPDATE_PLAYER"; updates: Partial<PlayerState> }
+  | { type: "SET_STORY_FLAG"; flag: string; value: boolean };
+
+/** ゲーム状態のReducer */
+export function gameReducer(state: GameState, action: GameAction): GameState {
+  switch (action.type) {
+    case "START_NEW_GAME":
+      return {
+        ...state,
+        screen: "starter_select",
+        player: createNewPlayerState(action.playerName),
+      };
+    case "CHANGE_SCREEN":
+      return { ...state, screen: action.screen };
+    case "SET_STARTER":
+      if (!state.player) return state;
+      return {
+        ...state,
+        screen: "overworld",
+        player: {
+          ...state.player,
+          partyState: {
+            ...state.player.partyState,
+            party: [action.monster],
+          },
+          pokedexSeen: new Set([...state.player.pokedexSeen, action.monster.speciesId]),
+          pokedexCaught: new Set([...state.player.pokedexCaught, action.monster.speciesId]),
+        },
+      };
+    case "UPDATE_PLAYER":
+      if (!state.player) return state;
+      return {
+        ...state,
+        player: { ...state.player, ...action.updates },
+      };
+    case "SET_STORY_FLAG":
+      return {
+        ...state,
+        storyFlags: { ...state.storyFlags, [action.flag]: action.value },
+      };
+    default:
+      return state;
+  }
+}


### PR DESCRIPTION
## Summary
- ゲーム状態管理（GameProvider: React Context + useReducer パターン）
- タイトル画面（はじめから/つづきから選択、プレイヤー名入力）
- スターター選択画面（御三家3匹のカード表示、キーボード/マウス操作、確認ダイアログ）
- テキストメッセージシステム（タイプライター演出、ページ送り、選択肢表示）
- Game コンポーネントによる画面遷移ルーティング
- Next.js ビルド確認済み
- テスト7件追加（合計140件）

## Closes
- Closes #54 (タイトル画面 & ゲーム開始フロー)
- Closes #58 (スターター選択画面)
- Closes #81 (テキストメッセージシステム)

## Test plan
- [x] 全140テストがパス
- [x] TypeScript型チェック通過
- [x] ESLint通過
- [x] Prettierフォーマット適用済み
- [x] Next.js ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)