### PR TITLE
feat: バトルUI・パーティ・バッグ・メニュー・図鑑画面 (Epic 8)

### DIFF
--- a/src/components/screens/BagScreen.tsx
+++ b/src/components/screens/BagScreen.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useState } from "react";
+
+/**
+ * バッグ画面 (#69)
+ * アイテム一覧、使用
+ */
+
+export interface BagItemInfo {
+  itemId: string;
+  name: string;
+  description: string;
+  category: string;
+  quantity: number;
+  usable: boolean;
+}
+
+export interface BagScreenProps {
+  items: BagItemInfo[];
+  onUse?: (itemId: string) => void;
+  onBack: () => void;
+}
+
+const CATEGORY_LABELS: Record<string, string> = {
+  medicine: "くすり",
+  ball: "ボール",
+  battle: "せんとう",
+  key: "たいせつなもの",
+};
+
+const CATEGORY_ORDER = ["medicine", "ball", "battle", "key"];
+
+export function BagScreen({ items, onUse, onBack }: BagScreenProps) {
+  const [selectedCategory, setSelectedCategory] = useState(0);
+  const [selectedItem, setSelectedItem] = useState(0);
+
+  const currentCategory = CATEGORY_ORDER[selectedCategory];
+  const filteredItems = items.filter((item) => item.category === currentCategory);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "ArrowLeft" || e.key === "a") {
+      setSelectedCategory((prev) => (prev - 1 + CATEGORY_ORDER.length) % CATEGORY_ORDER.length);
+      setSelectedItem(0);
+    }
+    if (e.key === "ArrowRight" || e.key === "d") {
+      setSelectedCategory((prev) => (prev + 1) % CATEGORY_ORDER.length);
+      setSelectedItem(0);
+    }
+    if (e.key === "ArrowUp" || e.key === "w") {
+      setSelectedItem((prev) => Math.max(0, prev - 1));
+    }
+    if (e.key === "ArrowDown" || e.key === "s") {
+      setSelectedItem((prev) => Math.min(filteredItems.length - 1, prev + 1));
+    }
+    if (e.key === "Enter" || e.key === "z") {
+      const item = filteredItems[selectedItem];
+      if (item?.usable) {
+        onUse?.(item.itemId);
+      }
+    }
+    if (e.key === "Escape" || e.key === "x") {
+      onBack();
+    }
+  };
+
+  return (
+    <div
+      className="flex min-h-screen flex-col bg-gray-950 p-6"
+      onKeyDown={handleKeyDown}
+      tabIndex={0}
+    >
+      {/* カテゴリタブ */}
+      <div className="mb-4 flex gap-2">
+        {CATEGORY_ORDER.map((cat, i) => (
+          <button
+            key={cat}
+            className={`rounded-t px-4 py-2 font-mono text-sm transition-colors ${
+              i === selectedCategory
+                ? "bg-gray-800 text-white"
+                : "bg-gray-900 text-gray-500 hover:text-gray-300"
+            }`}
+            onClick={() => {
+              setSelectedCategory(i);
+              setSelectedItem(0);
+            }}
+          >
+            {CATEGORY_LABELS[cat] ?? cat}
+          </button>
+        ))}
+      </div>
+
+      {/* アイテムリスト */}
+      <div className="flex flex-1 gap-4">
+        <div className="flex-1 space-y-1">
+          {filteredItems.length === 0 ? (
+            <p className="py-4 text-center font-mono text-gray-500">
+              このカテゴリにはアイテムがありません
+            </p>
+          ) : (
+            filteredItems.map((item, i) => (
+              <button
+                key={item.itemId}
+                className={`flex w-full items-center justify-between rounded px-4 py-2 text-left font-mono transition-colors ${
+                  i === selectedItem ? "bg-white/10 text-white" : "text-gray-400 hover:bg-white/5"
+                }`}
+                onClick={() => {
+                  setSelectedItem(i);
+                  if (item.usable) onUse?.(item.itemId);
+                }}
+                onMouseEnter={() => setSelectedItem(i)}
+              >
+                <span>{item.name}</span>
+                <span className="text-gray-500">×{item.quantity}</span>
+              </button>
+            ))
+          )}
+        </div>
+
+        {/* アイテム説明 */}
+        <div className="w-64 rounded-lg bg-gray-900 p-4">
+          {filteredItems[selectedItem] ? (
+            <>
+              <h3 className="font-mono font-bold text-white">{filteredItems[selectedItem].name}</h3>
+              <p className="mt-2 font-mono text-sm text-gray-400">
+                {filteredItems[selectedItem].description}
+              </p>
+              {filteredItems[selectedItem].usable && (
+                <button
+                  className="mt-4 rounded bg-emerald-600 px-4 py-1 font-mono text-sm text-white hover:bg-emerald-500"
+                  onClick={() => onUse?.(filteredItems[selectedItem].itemId)}
+                >
+                  つかう
+                </button>
+              )}
+            </>
+          ) : (
+            <p className="font-mono text-sm text-gray-600">アイテムを選んでください</p>
+          )}
+        </div>
+      </div>
+
+      <button
+        className="mt-4 self-start rounded bg-gray-700 px-4 py-2 font-mono text-sm text-gray-300 hover:bg-gray-600"
+        onClick={onBack}
+      >
+        もどる
+      </button>
+    </div>
+  );
+}

--- a/src/components/screens/BattleScreen.tsx
+++ b/src/components/screens/BattleScreen.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import { useState } from "react";
+import { HpBar } from "../ui/HpBar";
+
+/**
+ * バトルUI (#61)
+ * HPバー、技選択、メッセージウィンドウ、アクション選択
+ */
+
+export interface BattleMonsterInfo {
+  name: string;
+  level: number;
+  currentHp: number;
+  maxHp: number;
+  isPlayer: boolean;
+}
+
+export interface BattleMoveInfo {
+  moveId: string;
+  name: string;
+  type: string;
+  currentPp: number;
+  maxPp: number;
+}
+
+export type BattleAction =
+  | { type: "fight"; moveIndex: number }
+  | { type: "bag" }
+  | { type: "pokemon" }
+  | { type: "run" };
+
+export interface BattleScreenProps {
+  player: BattleMonsterInfo;
+  opponent: BattleMonsterInfo;
+  moves: BattleMoveInfo[];
+  messages: string[];
+  isWild: boolean;
+  onAction: (action: BattleAction) => void;
+  /** trueの場合、メッセージ表示中でアクション選択不可 */
+  isProcessing: boolean;
+}
+
+type BattlePhase = "action" | "move_select";
+
+export function BattleScreen({
+  player,
+  opponent,
+  moves,
+  messages,
+  isWild,
+  onAction,
+  isProcessing,
+}: BattleScreenProps) {
+  const [phase, setPhase] = useState<BattlePhase>("action");
+  const [selectedAction, setSelectedAction] = useState(0);
+  const [selectedMove, setSelectedMove] = useState(0);
+
+  const actions = [
+    { label: "たたかう", value: "fight" },
+    { label: "バッグ", value: "bag" },
+    { label: "ポケモン", value: "pokemon" },
+    { label: isWild ? "にげる" : "---", value: "run" },
+  ];
+
+  const handleActionSelect = (index: number) => {
+    const action = actions[index];
+    if (action.value === "fight") {
+      setPhase("move_select");
+      setSelectedMove(0);
+    } else if (action.value === "bag") {
+      onAction({ type: "bag" });
+    } else if (action.value === "pokemon") {
+      onAction({ type: "pokemon" });
+    } else if (action.value === "run" && isWild) {
+      onAction({ type: "run" });
+    }
+  };
+
+  const handleMoveSelect = (index: number) => {
+    if (moves[index] && moves[index].currentPp > 0) {
+      onAction({ type: "fight", moveIndex: index });
+      setPhase("action");
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (isProcessing) return;
+
+    if (phase === "action") {
+      if (e.key === "ArrowUp" || e.key === "w") {
+        setSelectedAction((prev) => (prev < 2 ? prev : prev - 2));
+      }
+      if (e.key === "ArrowDown" || e.key === "s") {
+        setSelectedAction((prev) => (prev >= 2 ? prev : prev + 2));
+      }
+      if (e.key === "ArrowLeft" || e.key === "a") {
+        setSelectedAction((prev) => (prev % 2 === 0 ? prev : prev - 1));
+      }
+      if (e.key === "ArrowRight" || e.key === "d") {
+        setSelectedAction((prev) => (prev % 2 === 1 ? prev : prev + 1));
+      }
+      if (e.key === "Enter" || e.key === "z") {
+        handleActionSelect(selectedAction);
+      }
+    } else if (phase === "move_select") {
+      if (e.key === "ArrowUp" || e.key === "w") {
+        setSelectedMove((prev) => (prev < 2 ? prev : prev - 2));
+      }
+      if (e.key === "ArrowDown" || e.key === "s") {
+        setSelectedMove((prev) =>
+          prev >= 2 && prev < moves.length ? prev : prev + 2 < moves.length ? prev + 2 : prev,
+        );
+      }
+      if (e.key === "ArrowLeft" || e.key === "a") {
+        setSelectedMove((prev) => (prev % 2 === 0 ? prev : prev - 1));
+      }
+      if (e.key === "ArrowRight" || e.key === "d") {
+        setSelectedMove((prev) => (prev % 2 === 1 || prev + 1 >= moves.length ? prev : prev + 1));
+      }
+      if (e.key === "Enter" || e.key === "z") {
+        handleMoveSelect(selectedMove);
+      }
+      if (e.key === "Escape" || e.key === "x") {
+        setPhase("action");
+      }
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col bg-gray-950" onKeyDown={handleKeyDown} tabIndex={0}>
+      {/* バトルフィールド */}
+      <div className="flex flex-1 flex-col justify-between px-8 py-6">
+        {/* 相手モンスター情報 */}
+        <div className="flex justify-start">
+          <div className="rounded-lg bg-gray-900/80 px-4 py-2">
+            <div className="flex items-baseline gap-2">
+              <span className="font-mono text-lg font-bold text-white">{opponent.name}</span>
+              <span className="font-mono text-sm text-gray-400">Lv.{opponent.level}</span>
+            </div>
+            <HpBar current={opponent.currentHp} max={opponent.maxHp} className="mt-1 w-40" />
+          </div>
+        </div>
+
+        {/* バトルアリーナ（プレースホルダー） */}
+        <div className="flex items-center justify-center py-8">
+          <div className="flex gap-32">
+            <div className="flex h-24 w-24 items-center justify-center rounded-full bg-gray-800 text-4xl">
+              👾
+            </div>
+            <div className="flex h-24 w-24 items-center justify-center rounded-full bg-gray-800 text-4xl">
+              🐾
+            </div>
+          </div>
+        </div>
+
+        {/* 自分モンスター情報 */}
+        <div className="flex justify-end">
+          <div className="rounded-lg bg-gray-900/80 px-4 py-2">
+            <div className="flex items-baseline gap-2">
+              <span className="font-mono text-lg font-bold text-white">{player.name}</span>
+              <span className="font-mono text-sm text-gray-400">Lv.{player.level}</span>
+            </div>
+            <HpBar current={player.currentHp} max={player.maxHp} className="mt-1 w-40" />
+          </div>
+        </div>
+      </div>
+
+      {/* メッセージ + コマンドウィンドウ */}
+      <div className="border-t-2 border-gray-700 bg-gray-900">
+        {isProcessing ? (
+          /* メッセージ表示 */
+          <div className="min-h-[6rem] px-6 py-4">
+            <p className="font-mono text-lg text-white">{messages[messages.length - 1] ?? ""}</p>
+          </div>
+        ) : phase === "action" ? (
+          /* アクション選択 */
+          <div className="flex">
+            <div className="flex-1 px-6 py-4">
+              <p className="font-mono text-lg text-white">{player.name}はどうする？</p>
+            </div>
+            <div className="grid w-56 grid-cols-2 gap-1 px-4 py-3">
+              {actions.map((action, i) => (
+                <button
+                  key={action.value}
+                  className={`rounded px-3 py-1.5 text-left font-mono text-sm transition-colors ${
+                    i === selectedAction
+                      ? "bg-white/20 text-white"
+                      : "text-gray-400 hover:text-white"
+                  }`}
+                  onClick={() => handleActionSelect(i)}
+                  onMouseEnter={() => setSelectedAction(i)}
+                >
+                  {i === selectedAction ? "▶" : " "} {action.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : (
+          /* 技選択 */
+          <div className="flex">
+            <div className="flex-1 px-4 py-3">
+              <div className="grid grid-cols-2 gap-1">
+                {moves.map((move, i) => (
+                  <button
+                    key={move.moveId}
+                    className={`rounded px-3 py-1.5 text-left font-mono text-sm transition-colors ${
+                      i === selectedMove
+                        ? "bg-white/20 text-white"
+                        : move.currentPp > 0
+                          ? "text-gray-400 hover:text-white"
+                          : "text-gray-600"
+                    }`}
+                    onClick={() => handleMoveSelect(i)}
+                    onMouseEnter={() => setSelectedMove(i)}
+                    disabled={move.currentPp <= 0}
+                  >
+                    {i === selectedMove ? "▶" : " "} {move.name}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="w-40 border-l border-gray-700 px-4 py-3">
+              {moves[selectedMove] && (
+                <>
+                  <p className="font-mono text-xs text-gray-400">
+                    タイプ/{moves[selectedMove].type}
+                  </p>
+                  <p className="font-mono text-xs text-gray-400">
+                    PP {moves[selectedMove].currentPp}/{moves[selectedMove].maxPp}
+                  </p>
+                </>
+              )}
+              <button
+                className="mt-2 font-mono text-xs text-gray-500 hover:text-white"
+                onClick={() => setPhase("action")}
+              >
+                ← もどる
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/screens/MenuScreen.tsx
+++ b/src/components/screens/MenuScreen.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState } from "react";
+
+/**
+ * メニュー画面 (#77)
+ * ゲーム中のメインメニュー
+ */
+
+export interface MenuScreenProps {
+  playerName: string;
+  badgeCount: number;
+  playTime?: string;
+  onNavigate: (screen: string) => void;
+  onSave?: () => void;
+  onBack: () => void;
+}
+
+interface MenuItem {
+  label: string;
+  value: string;
+  description: string;
+}
+
+const MENU_ITEMS: MenuItem[] = [
+  { label: "ポケモン", value: "party", description: "手持ちのモンスターを確認する" },
+  { label: "バッグ", value: "bag", description: "持ち物を確認する" },
+  { label: "図鑑", value: "pokedex", description: "見つけたモンスターを確認する" },
+  { label: "レポート", value: "save", description: "冒険の記録を書く" },
+  { label: "設定", value: "settings", description: "ゲームの設定を変更する" },
+  { label: "とじる", value: "close", description: "メニューを閉じる" },
+];
+
+export function MenuScreen({
+  playerName,
+  badgeCount,
+  onNavigate,
+  onSave,
+  onBack,
+}: MenuScreenProps) {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  const handleSelect = (index: number) => {
+    const item = MENU_ITEMS[index];
+    if (item.value === "close") {
+      onBack();
+    } else if (item.value === "save") {
+      onSave?.();
+    } else {
+      onNavigate(item.value);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "ArrowUp" || e.key === "w") {
+      setSelectedIndex((prev) => (prev - 1 + MENU_ITEMS.length) % MENU_ITEMS.length);
+    }
+    if (e.key === "ArrowDown" || e.key === "s") {
+      setSelectedIndex((prev) => (prev + 1) % MENU_ITEMS.length);
+    }
+    if (e.key === "Enter" || e.key === "z") {
+      handleSelect(selectedIndex);
+    }
+    if (e.key === "Escape" || e.key === "x") {
+      onBack();
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-40 flex items-start justify-end bg-black/50 p-4"
+      onKeyDown={handleKeyDown}
+      tabIndex={0}
+    >
+      <div className="w-56 rounded-lg border-2 border-gray-600 bg-gray-900 shadow-xl">
+        {/* プレイヤー情報 */}
+        <div className="border-b border-gray-700 px-4 py-3">
+          <p className="font-mono text-sm text-gray-400">{playerName}</p>
+          <p className="font-mono text-xs text-gray-500">バッジ: {badgeCount}個</p>
+        </div>
+
+        {/* メニュー項目 */}
+        <div className="py-2">
+          {MENU_ITEMS.map((item, i) => (
+            <button
+              key={item.value}
+              className={`flex w-full items-center px-4 py-2 text-left font-mono text-sm transition-colors ${
+                i === selectedIndex ? "bg-white/10 text-white" : "text-gray-400 hover:text-white"
+              }`}
+              onClick={() => handleSelect(i)}
+              onMouseEnter={() => setSelectedIndex(i)}
+            >
+              {i === selectedIndex ? "▶ " : "  "}
+              {item.label}
+            </button>
+          ))}
+        </div>
+
+        {/* 説明文 */}
+        <div className="border-t border-gray-700 px-4 py-2">
+          <p className="font-mono text-xs text-gray-500">{MENU_ITEMS[selectedIndex].description}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/screens/PartyScreen.tsx
+++ b/src/components/screens/PartyScreen.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useState } from "react";
+import { HpBar } from "../ui/HpBar";
+
+/**
+ * パーティ画面 (#65)
+ * ステータス確認、並び替え
+ */
+
+export interface PartyMemberInfo {
+  speciesId: string;
+  name: string;
+  level: number;
+  currentHp: number;
+  maxHp: number;
+  status: string | null;
+  types: string[];
+}
+
+export interface PartyScreenProps {
+  party: PartyMemberInfo[];
+  onSwap?: (indexA: number, indexB: number) => void;
+  onSelect?: (index: number) => void;
+  onBack: () => void;
+  /** 交代選択モード（バトル中） */
+  selectMode?: boolean;
+}
+
+const STATUS_LABELS: Record<string, { text: string; color: string }> = {
+  poison: { text: "どく", color: "text-purple-400" },
+  burn: { text: "やけど", color: "text-orange-400" },
+  paralysis: { text: "まひ", color: "text-yellow-400" },
+  sleep: { text: "ねむり", color: "text-gray-400" },
+  freeze: { text: "こおり", color: "text-cyan-400" },
+};
+
+export function PartyScreen({
+  party,
+  onSwap,
+  onSelect,
+  onBack,
+  selectMode = false,
+}: PartyScreenProps) {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [swapSource, setSwapSource] = useState<number | null>(null);
+
+  const handleSelect = (index: number) => {
+    if (selectMode) {
+      onSelect?.(index);
+      return;
+    }
+
+    if (swapSource !== null) {
+      if (swapSource !== index) {
+        onSwap?.(swapSource, index);
+      }
+      setSwapSource(null);
+    } else {
+      setSwapSource(index);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "ArrowUp" || e.key === "w") {
+      setSelectedIndex((prev) => Math.max(0, prev - 1));
+    }
+    if (e.key === "ArrowDown" || e.key === "s") {
+      setSelectedIndex((prev) => Math.min(party.length - 1, prev + 1));
+    }
+    if (e.key === "Enter" || e.key === "z") {
+      handleSelect(selectedIndex);
+    }
+    if (e.key === "Escape" || e.key === "x") {
+      if (swapSource !== null) {
+        setSwapSource(null);
+      } else {
+        onBack();
+      }
+    }
+  };
+
+  return (
+    <div
+      className="flex min-h-screen flex-col bg-gray-950 p-6"
+      onKeyDown={handleKeyDown}
+      tabIndex={0}
+    >
+      <h2 className="mb-4 font-mono text-xl text-white">
+        {selectMode ? "モンスターを選んでください" : "てもち"}
+      </h2>
+
+      <div className="space-y-2">
+        {party.map((member, i) => {
+          const isFainted = member.currentHp <= 0;
+          const isSwapSource = swapSource === i;
+          const isSelected = selectedIndex === i;
+
+          return (
+            <button
+              key={i}
+              className={`flex w-full items-center gap-4 rounded-lg border-2 px-4 py-3 text-left transition-all ${
+                isSwapSource
+                  ? "border-yellow-500 bg-yellow-900/20"
+                  : isSelected
+                    ? "border-white/30 bg-white/10"
+                    : "border-gray-700 bg-gray-900"
+              } ${isFainted ? "opacity-50" : ""}`}
+              onClick={() => handleSelect(i)}
+              onMouseEnter={() => setSelectedIndex(i)}
+            >
+              {/* アイコンプレースホルダー */}
+              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gray-800 text-xl">
+                {isFainted ? "💀" : "🐾"}
+              </div>
+
+              <div className="flex-1">
+                <div className="flex items-baseline gap-2">
+                  <span className="font-mono font-bold text-white">{member.name}</span>
+                  <span className="font-mono text-sm text-gray-400">Lv.{member.level}</span>
+                  {member.status && STATUS_LABELS[member.status] && (
+                    <span className={`font-mono text-xs ${STATUS_LABELS[member.status].color}`}>
+                      [{STATUS_LABELS[member.status].text}]
+                    </span>
+                  )}
+                </div>
+                <HpBar current={member.currentHp} max={member.maxHp} className="mt-1 w-48" />
+              </div>
+
+              <div className="font-mono text-xs text-gray-500">{member.types.join(" / ")}</div>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="mt-4 flex gap-4">
+        <button
+          className="rounded bg-gray-700 px-4 py-2 font-mono text-sm text-gray-300 hover:bg-gray-600"
+          onClick={onBack}
+        >
+          もどる
+        </button>
+        {swapSource !== null && (
+          <span className="font-mono text-sm text-yellow-400">
+            入れ替え先を選んでください（Escでキャンセル）
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/screens/PokedexScreen.tsx
+++ b/src/components/screens/PokedexScreen.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useState } from "react";
+
+/**
+ * 図鑑UI (#73)
+ * 一覧、詳細、捕獲状況
+ */
+
+export interface PokedexEntry {
+  id: string;
+  name: string;
+  types: string[];
+  description: string;
+  /** 見たことがある */
+  seen: boolean;
+  /** 捕まえたことがある */
+  caught: boolean;
+}
+
+export interface PokedexScreenProps {
+  entries: PokedexEntry[];
+  onBack: () => void;
+}
+
+const TYPE_COLORS: Record<string, string> = {
+  normal: "bg-gray-500",
+  fire: "bg-orange-500",
+  water: "bg-blue-500",
+  grass: "bg-green-500",
+  electric: "bg-yellow-500",
+  ice: "bg-cyan-400",
+  fighting: "bg-red-700",
+  poison: "bg-purple-500",
+  ground: "bg-amber-700",
+  flying: "bg-indigo-300",
+  psychic: "bg-pink-500",
+  bug: "bg-lime-500",
+  rock: "bg-amber-800",
+  ghost: "bg-purple-800",
+  dragon: "bg-violet-700",
+  dark: "bg-gray-800",
+  steel: "bg-gray-400",
+  fairy: "bg-pink-300",
+};
+
+export function PokedexScreen({ entries, onBack }: PokedexScreenProps) {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  const seenCount = entries.filter((e) => e.seen).length;
+  const caughtCount = entries.filter((e) => e.caught).length;
+  const selected = entries[selectedIndex];
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "ArrowUp" || e.key === "w") {
+      setSelectedIndex((prev) => Math.max(0, prev - 1));
+    }
+    if (e.key === "ArrowDown" || e.key === "s") {
+      setSelectedIndex((prev) => Math.min(entries.length - 1, prev + 1));
+    }
+    if (e.key === "Escape" || e.key === "x") {
+      onBack();
+    }
+  };
+
+  return (
+    <div
+      className="flex min-h-screen flex-col bg-gray-950 p-6"
+      onKeyDown={handleKeyDown}
+      tabIndex={0}
+    >
+      {/* ヘッダー */}
+      <div className="mb-4 flex items-baseline justify-between">
+        <h2 className="font-mono text-xl text-white">モンスター図鑑</h2>
+        <div className="font-mono text-sm text-gray-400">
+          みつけた: {seenCount} / つかまえた: {caughtCount}
+        </div>
+      </div>
+
+      <div className="flex flex-1 gap-4">
+        {/* 一覧 */}
+        <div className="w-64 space-y-0.5 overflow-y-auto">
+          {entries.map((entry, i) => (
+            <button
+              key={entry.id}
+              className={`flex w-full items-center gap-2 rounded px-3 py-1.5 text-left font-mono text-sm transition-colors ${
+                i === selectedIndex ? "bg-white/10 text-white" : "text-gray-500 hover:text-gray-300"
+              }`}
+              onClick={() => setSelectedIndex(i)}
+              onMouseEnter={() => setSelectedIndex(i)}
+            >
+              <span className="w-4 text-xs">{entry.caught ? "●" : entry.seen ? "○" : " "}</span>
+              <span>{entry.seen ? entry.name : "？？？"}</span>
+            </button>
+          ))}
+        </div>
+
+        {/* 詳細 */}
+        <div className="flex-1 rounded-lg bg-gray-900 p-6">
+          {selected && selected.seen ? (
+            <>
+              <h3 className="font-mono text-2xl font-bold text-white">{selected.name}</h3>
+              <div className="mt-2 flex gap-2">
+                {selected.types.map((type) => (
+                  <span
+                    key={type}
+                    className={`rounded px-2 py-0.5 font-mono text-xs text-white ${TYPE_COLORS[type] ?? "bg-gray-600"}`}
+                  >
+                    {type}
+                  </span>
+                ))}
+              </div>
+              <p className="mt-4 font-mono text-gray-300">{selected.description}</p>
+              <p className="mt-4 font-mono text-sm text-gray-500">
+                {selected.caught ? "つかまえた！" : "まだつかまえていない"}
+              </p>
+            </>
+          ) : (
+            <p className="font-mono text-gray-600">データがありません</p>
+          )}
+        </div>
+      </div>
+
+      <button
+        className="mt-4 self-start rounded bg-gray-700 px-4 py-2 font-mono text-sm text-gray-300 hover:bg-gray-600"
+        onClick={onBack}
+      >
+        もどる
+      </button>
+    </div>
+  );
+}

--- a/src/components/ui/HpBar.tsx
+++ b/src/components/ui/HpBar.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+/**
+ * HPバー (#61)
+ * HP残量に応じて色が変化（緑→黄→赤）
+ */
+
+export interface HpBarProps {
+  current: number;
+  max: number;
+  /** バーの幅クラス */
+  className?: string;
+}
+
+function getHpColor(ratio: number): string {
+  if (ratio > 0.5) return "bg-emerald-500";
+  if (ratio > 0.2) return "bg-yellow-500";
+  return "bg-red-500";
+}
+
+export function HpBar({ current, max, className = "w-32" }: HpBarProps) {
+  const ratio = max > 0 ? Math.max(0, Math.min(1, current / max)) : 0;
+  const percent = Math.round(ratio * 100);
+
+  return (
+    <div className={`${className}`}>
+      <div className="flex items-center gap-2">
+        <span className="font-mono text-xs text-gray-400">HP</span>
+        <div className="h-2 flex-1 overflow-hidden rounded-full bg-gray-700">
+          <div
+            className={`h-full rounded-full transition-all duration-300 ${getHpColor(ratio)}`}
+            style={{ width: `${percent}%` }}
+          />
+        </div>
+      </div>
+      <div className="mt-0.5 text-right font-mono text-xs text-gray-300">
+        {current} / {max}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- バトルUI（HPバー、アクション選択4択、技選択2×2、メッセージウィンドウ）
- HPバーコンポーネント（HP割合に応じた色変化: 緑→黄→赤）
- パーティ画面（ステータス確認、並び替え操作、バトル中交代モード対応）
- バッグ画面（4カテゴリタブ、アイテム一覧/説明/使用）
- メニュー画面（オーバーレイ、6項目ナビゲーション）
- 図鑑UI（一覧/詳細表示、見た数/捕まえた数、タイプバッジ表示）
- 全画面キーボード + マウス操作対応
- Next.js ビルド成功確認済み

## Closes
- Closes #61 (バトルUI)
- Closes #65 (パーティ画面)
- Closes #69 (バッグ画面)
- Closes #73 (図鑑UI)
- Closes #77 (メニュー画面)

## Test plan
- [x] 全140テストがパス
- [x] TypeScript型チェック通過
- [x] ESLint通過
- [x] Next.js ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)