### PR TITLE
feat: オーバーワールドシステム (Epic 7 残り)

### DIFF
--- a/src/components/screens/OverworldScreen.tsx
+++ b/src/components/screens/OverworldScreen.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
+import type { MapDefinition } from "@/engine/map/map-data";
+import type { PlayerPosition, Direction } from "@/engine/map/player-movement";
+import { movePlayer, getFacingNpc } from "@/engine/map/player-movement";
+import { MessageWindow } from "../ui/MessageWindow";
+
+/**
+ * オーバーワールド画面 (#28)
+ * DOMベースのグリッドマップ表示
+ */
+
+const TILE_SIZE = 32;
+const VIEWPORT_TILES_X = 15;
+const VIEWPORT_TILES_Y = 11;
+
+export interface OverworldScreenProps {
+  map: MapDefinition;
+  initialPosition: PlayerPosition;
+  onMapTransition?: (targetMapId: string, targetX: number, targetY: number) => void;
+  onEncounter?: () => void;
+  onNpcInteract?: (npcId: string) => void;
+  onMenuOpen?: () => void;
+}
+
+const TILE_COLORS: Record<string, string> = {
+  ground: "bg-amber-100",
+  wall: "bg-gray-600",
+  grass: "bg-green-400",
+  water: "bg-blue-400",
+  ledge: "bg-amber-300",
+  door: "bg-amber-800",
+  sign: "bg-amber-600",
+};
+
+const DIRECTION_KEYS: Record<string, Direction> = {
+  ArrowUp: "up",
+  ArrowDown: "down",
+  ArrowLeft: "left",
+  ArrowRight: "right",
+  w: "up",
+  s: "down",
+  a: "left",
+  d: "right",
+};
+
+export function OverworldScreen({
+  map,
+  initialPosition,
+  onMapTransition,
+  onEncounter,
+  onNpcInteract,
+  onMenuOpen,
+}: OverworldScreenProps) {
+  const [position, setPosition] = useState<PlayerPosition>(initialPosition);
+  const [dialogueMessages, setDialogueMessages] = useState<string[] | null>(null);
+
+  const handleMove = useCallback(
+    (direction: Direction) => {
+      if (dialogueMessages) return; // 会話中は移動不可
+
+      const result = movePlayer(position, direction, map);
+      setPosition(result.position);
+
+      if (result.mapTransition) {
+        onMapTransition?.(
+          result.mapTransition.targetMapId,
+          result.mapTransition.targetX,
+          result.mapTransition.targetY,
+        );
+        return;
+      }
+
+      if (result.facingNpcId) {
+        onNpcInteract?.(result.facingNpcId);
+        const npc = map.npcs.find((n) => n.id === result.facingNpcId);
+        if (npc) {
+          setDialogueMessages(npc.dialogue);
+        }
+        return;
+      }
+
+      if (result.enteredEncounterTile) {
+        onEncounter?.();
+      }
+    },
+    [position, map, dialogueMessages, onMapTransition, onEncounter, onNpcInteract],
+  );
+
+  const handleInteract = useCallback(() => {
+    if (dialogueMessages) return;
+
+    const npcId = getFacingNpc(position, map);
+    if (npcId) {
+      onNpcInteract?.(npcId);
+      const npc = map.npcs.find((n) => n.id === npcId);
+      if (npc) {
+        setDialogueMessages(npc.dialogue);
+      }
+    }
+  }, [position, map, dialogueMessages, onNpcInteract]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const direction = DIRECTION_KEYS[e.key];
+      if (direction) {
+        e.preventDefault();
+        handleMove(direction);
+        return;
+      }
+
+      if (e.key === "z" || e.key === "Enter") {
+        e.preventDefault();
+        handleInteract();
+      }
+
+      if (e.key === "Escape" || e.key === "x") {
+        e.preventDefault();
+        onMenuOpen?.();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [handleMove, handleInteract, onMenuOpen]);
+
+  // ビューポートのオフセット計算（プレイヤーを中心に）
+  const offsetX = Math.max(
+    0,
+    Math.min(position.x - Math.floor(VIEWPORT_TILES_X / 2), map.width - VIEWPORT_TILES_X),
+  );
+  const offsetY = Math.max(
+    0,
+    Math.min(position.y - Math.floor(VIEWPORT_TILES_Y / 2), map.height - VIEWPORT_TILES_Y),
+  );
+
+  const visibleTilesX = Math.min(VIEWPORT_TILES_X, map.width);
+  const visibleTilesY = Math.min(VIEWPORT_TILES_Y, map.height);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-black">
+      <div
+        className="relative"
+        style={{ width: visibleTilesX * TILE_SIZE, height: visibleTilesY * TILE_SIZE }}
+      >
+        {/* マップタイル */}
+        {Array.from({ length: visibleTilesY }, (_, vy) =>
+          Array.from({ length: visibleTilesX }, (_, vx) => {
+            const mapX = vx + offsetX;
+            const mapY = vy + offsetY;
+            if (mapX >= map.width || mapY >= map.height) return null;
+            const tileType = map.tiles[mapY]?.[mapX] ?? "ground";
+            const bgColor = TILE_COLORS[tileType] ?? "bg-gray-500";
+
+            return (
+              <div
+                key={`${mapX}-${mapY}`}
+                className={`absolute ${bgColor}`}
+                style={{
+                  left: vx * TILE_SIZE,
+                  top: vy * TILE_SIZE,
+                  width: TILE_SIZE,
+                  height: TILE_SIZE,
+                }}
+              />
+            );
+          }),
+        )}
+
+        {/* NPC表示 */}
+        {map.npcs
+          .filter(
+            (npc) =>
+              npc.x >= offsetX &&
+              npc.x < offsetX + visibleTilesX &&
+              npc.y >= offsetY &&
+              npc.y < offsetY + visibleTilesY,
+          )
+          .map((npc) => (
+            <div
+              key={npc.id}
+              className="absolute flex items-center justify-center text-lg"
+              style={{
+                left: (npc.x - offsetX) * TILE_SIZE,
+                top: (npc.y - offsetY) * TILE_SIZE,
+                width: TILE_SIZE,
+                height: TILE_SIZE,
+              }}
+            >
+              {npc.isTrainer ? "⚔️" : "👤"}
+            </div>
+          ))}
+
+        {/* プレイヤー表示 */}
+        <div
+          className="absolute flex items-center justify-center text-lg transition-all duration-100"
+          style={{
+            left: (position.x - offsetX) * TILE_SIZE,
+            top: (position.y - offsetY) * TILE_SIZE,
+            width: TILE_SIZE,
+            height: TILE_SIZE,
+          }}
+        >
+          {position.direction === "up"
+            ? "⬆️"
+            : position.direction === "down"
+              ? "⬇️"
+              : position.direction === "left"
+                ? "⬅️"
+                : "➡️"}
+        </div>
+
+        {/* マップ名 */}
+        <div className="absolute left-2 top-2 rounded bg-black/60 px-2 py-0.5">
+          <span className="font-mono text-xs text-white">{map.name}</span>
+        </div>
+      </div>
+
+      {/* 会話ウィンドウ */}
+      {dialogueMessages && (
+        <MessageWindow messages={dialogueMessages} onComplete={() => setDialogueMessages(null)} />
+      )}
+    </div>
+  );
+}

--- a/src/engine/map/__tests__/npc.test.ts
+++ b/src/engine/map/__tests__/npc.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { interactWithNpc } from "../npc";
+import type { NpcDefinition } from "../map-data";
+
+const npcs: NpcDefinition[] = [
+  { id: "villager", name: "村人", x: 5, y: 5, dialogue: ["いい天気だね！"], isTrainer: false },
+  {
+    id: "trainer1",
+    name: "ミニスカート",
+    x: 8,
+    y: 3,
+    dialogue: ["勝負よ！", "悔しい〜！"],
+    isTrainer: true,
+  },
+];
+
+describe("NPC会話システム", () => {
+  it("村人に話しかけると会話が返る", () => {
+    const result = interactWithNpc("villager", npcs);
+    expect(result).not.toBeNull();
+    expect(result!.dialogue).toEqual(["いい天気だね！"]);
+    expect(result!.triggerBattle).toBe(false);
+  });
+
+  it("未撃破トレーナーに話しかけるとバトルが発生する", () => {
+    const result = interactWithNpc("trainer1", npcs);
+    expect(result).not.toBeNull();
+    expect(result!.triggerBattle).toBe(true);
+  });
+
+  it("撃破済みトレーナーにはバトルが発生しない", () => {
+    const defeated = new Set(["trainer1"]);
+    const result = interactWithNpc("trainer1", npcs, defeated);
+    expect(result).not.toBeNull();
+    expect(result!.triggerBattle).toBe(false);
+  });
+
+  it("存在しないNPCにはnullが返る", () => {
+    const result = interactWithNpc("unknown", npcs);
+    expect(result).toBeNull();
+  });
+});

--- a/src/engine/map/__tests__/player-movement.test.ts
+++ b/src/engine/map/__tests__/player-movement.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { movePlayer, getFacingNpc } from "../player-movement";
+import type { MapDefinition } from "../map-data";
+
+const testMap: MapDefinition = {
+  id: "test",
+  name: "テスト",
+  width: 5,
+  height: 5,
+  tiles: [
+    ["wall", "wall", "wall", "wall", "wall"],
+    ["wall", "ground", "ground", "ground", "wall"],
+    ["wall", "ground", "grass", "door", "wall"],
+    ["wall", "ground", "ground", "ground", "wall"],
+    ["wall", "wall", "wall", "wall", "wall"],
+  ],
+  connections: [{ targetMapId: "route-1", targetX: 0, targetY: 0, sourceX: 3, sourceY: 2 }],
+  encounters: [],
+  encounterRate: 20,
+  npcs: [{ id: "npc1", name: "村人", x: 3, y: 3, dialogue: ["こんにちは！"], isTrainer: false }],
+};
+
+describe("プレイヤー移動", () => {
+  it("空いている方向に移動できる", () => {
+    const result = movePlayer({ x: 1, y: 1, direction: "down" }, "down", testMap);
+    expect(result.moved).toBe(true);
+    expect(result.position).toEqual({ x: 1, y: 2, direction: "down" });
+  });
+
+  it("壁に向かって移動できない", () => {
+    const result = movePlayer({ x: 1, y: 1, direction: "up" }, "up", testMap);
+    expect(result.moved).toBe(false);
+    expect(result.position.x).toBe(1);
+    expect(result.position.y).toBe(1);
+    expect(result.position.direction).toBe("up"); // 向きだけ更新
+  });
+
+  it("草むらに入るとエンカウントフラグが立つ", () => {
+    const result = movePlayer({ x: 1, y: 2, direction: "right" }, "right", testMap);
+    expect(result.moved).toBe(true);
+    expect(result.enteredEncounterTile).toBe(true);
+  });
+
+  it("マップ接続座標に移動するとマップ遷移が発生する", () => {
+    const result = movePlayer({ x: 2, y: 2, direction: "right" }, "right", testMap);
+    expect(result.moved).toBe(true);
+    expect(result.mapTransition).not.toBeNull();
+    expect(result.mapTransition!.targetMapId).toBe("route-1");
+  });
+
+  it("NPCがいる場所には移動できない", () => {
+    const result = movePlayer({ x: 2, y: 3, direction: "right" }, "right", testMap);
+    expect(result.moved).toBe(false);
+    expect(result.facingNpcId).toBe("npc1");
+  });
+});
+
+describe("getFacingNpc", () => {
+  it("向いている方向にNPCがいれば返す", () => {
+    const npcId = getFacingNpc({ x: 2, y: 3, direction: "right" }, testMap);
+    expect(npcId).toBe("npc1");
+  });
+
+  it("向いている方向にNPCがいなければnull", () => {
+    const npcId = getFacingNpc({ x: 1, y: 1, direction: "up" }, testMap);
+    expect(npcId).toBeNull();
+  });
+});

--- a/src/engine/map/map-transition.ts
+++ b/src/engine/map/map-transition.ts
@@ -1,0 +1,38 @@
+import type { MapDefinition, MapConnection } from "./map-data";
+import type { PlayerPosition } from "./player-movement";
+
+/**
+ * マップ遷移 (#37)
+ * マップ間の移動を管理
+ */
+
+export interface MapTransitionResult {
+  /** 遷移先のマップID */
+  targetMapId: string;
+  /** プレイヤーの新しい位置 */
+  newPosition: PlayerPosition;
+}
+
+/**
+ * マップ遷移を実行
+ * @param connection 接続情報
+ * @param currentDirection プレイヤーの現在の向き
+ */
+export function executeMapTransition(
+  connection: MapConnection,
+  currentDirection: PlayerPosition["direction"],
+): MapTransitionResult {
+  return {
+    targetMapId: connection.targetMapId,
+    newPosition: {
+      x: connection.targetX,
+      y: connection.targetY,
+      direction: currentDirection,
+    },
+  };
+}
+
+/**
+ * マップIDからマップデータを取得するリゾルバの型定義
+ */
+export type MapResolver = (mapId: string) => MapDefinition | null;

--- a/src/engine/map/npc.ts
+++ b/src/engine/map/npc.ts
@@ -1,0 +1,36 @@
+import type { NpcDefinition } from "./map-data";
+
+/**
+ * NPC配置と会話システム (#41)
+ */
+
+export interface NpcInteractionResult {
+  npc: NpcDefinition;
+  /** 会話テキスト */
+  dialogue: string[];
+  /** トレーナー戦が発生するか */
+  triggerBattle: boolean;
+}
+
+/**
+ * NPCに話しかける
+ * @param npcId NPC ID
+ * @param npcs マップ上のNPC一覧
+ * @param defeatedTrainers 倒済みトレーナーIDのSet
+ */
+export function interactWithNpc(
+  npcId: string,
+  npcs: NpcDefinition[],
+  defeatedTrainers: Set<string> = new Set(),
+): NpcInteractionResult | null {
+  const npc = npcs.find((n) => n.id === npcId);
+  if (!npc) return null;
+
+  const alreadyDefeated = defeatedTrainers.has(npc.id);
+
+  return {
+    npc,
+    dialogue: npc.dialogue,
+    triggerBattle: npc.isTrainer && !alreadyDefeated,
+  };
+}

--- a/src/engine/map/player-movement.ts
+++ b/src/engine/map/player-movement.ts
@@ -1,0 +1,108 @@
+import type { MapDefinition } from "./map-data";
+import { isWalkable, getConnectionAt, getTileAt } from "./map-data";
+
+/**
+ * プレイヤー移動 & 衝突判定 (#31)
+ */
+
+export type Direction = "up" | "down" | "left" | "right";
+
+export interface PlayerPosition {
+  x: number;
+  y: number;
+  direction: Direction;
+}
+
+export interface MoveResult {
+  /** 移動できたか */
+  moved: boolean;
+  /** 新しい位置 */
+  position: PlayerPosition;
+  /** マップ遷移が発生したか */
+  mapTransition: { targetMapId: string; targetX: number; targetY: number } | null;
+  /** エンカウントタイル（草むら）を踏んだか */
+  enteredEncounterTile: boolean;
+  /** NPCに話しかける方向にNPCがいたか */
+  facingNpcId: string | null;
+}
+
+const DIRECTION_DELTA: Record<Direction, { dx: number; dy: number }> = {
+  up: { dx: 0, dy: -1 },
+  down: { dx: 0, dy: 1 },
+  left: { dx: -1, dy: 0 },
+  right: { dx: 1, dy: 0 },
+};
+
+/**
+ * プレイヤーを指定方向に1マス移動させる
+ */
+export function movePlayer(
+  currentPos: PlayerPosition,
+  direction: Direction,
+  map: MapDefinition,
+): MoveResult {
+  const { dx, dy } = DIRECTION_DELTA[direction];
+  const newX = currentPos.x + dx;
+  const newY = currentPos.y + dy;
+
+  const baseResult: MoveResult = {
+    moved: false,
+    position: { ...currentPos, direction },
+    mapTransition: null,
+    enteredEncounterTile: false,
+    facingNpcId: null,
+  };
+
+  // NPC衝突判定
+  const npcAtTarget = map.npcs.find((npc) => npc.x === newX && npc.y === newY);
+  if (npcAtTarget) {
+    return { ...baseResult, facingNpcId: npcAtTarget.id };
+  }
+
+  // 壁・範囲外判定
+  if (!isWalkable(map, newX, newY)) {
+    return baseResult;
+  }
+
+  const newPosition: PlayerPosition = { x: newX, y: newY, direction };
+
+  // マップ接続判定
+  const connection = getConnectionAt(map, newX, newY);
+  if (connection) {
+    return {
+      moved: true,
+      position: newPosition,
+      mapTransition: {
+        targetMapId: connection.targetMapId,
+        targetX: connection.targetX,
+        targetY: connection.targetY,
+      },
+      enteredEncounterTile: false,
+      facingNpcId: null,
+    };
+  }
+
+  // エンカウントタイル判定
+  const tile = getTileAt(map, newX, newY);
+  const enteredEncounterTile = tile?.encounter ?? false;
+
+  return {
+    moved: true,
+    position: newPosition,
+    mapTransition: null,
+    enteredEncounterTile,
+    facingNpcId: null,
+  };
+}
+
+/**
+ * 向いている方向のNPCを取得（Aボタン相当）
+ */
+export function getFacingNpc(position: PlayerPosition, map: MapDefinition): string | null {
+  const { dx, dy } = DIRECTION_DELTA[position.direction];
+  const facingX = position.x + dx;
+  const facingY = position.y + dy;
+
+  const npc = map.npcs.find((n) => n.x === facingX && n.y === facingY);
+  return npc?.id ?? null;
+}


### PR DESCRIPTION
## Summary
- プレイヤー移動エンジン（方向移動、壁衝突、NPC衝突、範囲外判定）
- マップ遷移ロジック（接続座標自動検出、遷移先マップ/座標解決）
- NPC会話システム（話しかけ判定、会話テキスト表示、トレーナー戦フラグ、撃破済み判定）
- オーバーワールド画面（DOMベースタイルグリッド、ビューポートスクロール、NPC/プレイヤー表示）
- キーボード操作（矢印キー/WASD移動、Z/Enterで話しかけ、Escでメニュー）
- テスト11件追加（合計151件）

## Closes
- Closes #28 (オーバーワールド画面)
- Closes #31 (プレイヤー移動 & 衝突判定)
- Closes #37 (マップ遷移)
- Closes #41 (NPC配置と会話システム)

## Test plan
- [x] 全151テストがパス
- [x] TypeScript型チェック通過
- [x] ESLint通過
- [x] Next.js ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)