### PR TITLE
fix: 包括的監査バグ修正・設計改善・テスト補強

### DIFF
--- a/src/components/screens/StarterSelect.tsx
+++ b/src/components/screens/StarterSelect.tsx
@@ -86,8 +86,11 @@ export function StarterSelect({ starters, onSelect, professorName = "博士" }: 
                   : "border-gray-700 bg-gray-900 text-gray-500 hover:border-gray-500"
               }`}
               onClick={() => {
-                setSelectedIndex(i);
-                if (isSelected) setConfirming(true);
+                if (i === selectedIndex) {
+                  setConfirming(true);
+                } else {
+                  setSelectedIndex(i);
+                }
               }}
             >
               {/* モンスターアイコン（プレースホルダー） */}

--- a/src/engine/battle/state-machine.ts
+++ b/src/engine/battle/state-machine.ts
@@ -43,6 +43,8 @@ export interface BattleState {
   player: BattlerState;
   opponent: BattlerState;
   turnNumber: number;
+  /** 逃走試行回数 */
+  escapeAttempts: number;
   /** 直近のメッセージログ */
   messages: string[];
   /** バトル結果（終了時のみ） */
@@ -68,6 +70,7 @@ export function initBattle(
     player: { party: playerParty, activeIndex: 0 },
     opponent: { party: opponentParty, activeIndex: 0 },
     turnNumber: 1,
+    escapeAttempts: 0,
     messages: [],
     result: null,
   };

--- a/src/engine/battle/turn-order.ts
+++ b/src/engine/battle/turn-order.ts
@@ -1,5 +1,6 @@
 import type { MonsterInstance, MonsterSpecies, MoveDefinition } from "@/types";
 import { calcAllStats } from "@/engine/monster/stats";
+import { getStatusEffect } from "./status";
 import type { BattleAction } from "./state-machine";
 
 export interface TurnAction {
@@ -46,20 +47,26 @@ export function determineTurnOrder(
       : [opponentAction, playerAction];
   }
 
-  // 素早さ比較
-  const playerSpeed = calcAllStats(
+  // 素早さ比較（状態異常の影響を適用）
+  let playerSpeed = calcAllStats(
     playerAction.species.baseStats,
     playerAction.monster.ivs,
     playerAction.monster.evs,
     playerAction.monster.level,
   ).speed;
+  if (playerAction.monster.status) {
+    playerSpeed = Math.floor(playerSpeed * getStatusEffect(playerAction.monster.status).speedModifier);
+  }
 
-  const opponentSpeed = calcAllStats(
+  let opponentSpeed = calcAllStats(
     opponentAction.species.baseStats,
     opponentAction.monster.ivs,
     opponentAction.monster.evs,
     opponentAction.monster.level,
   ).speed;
+  if (opponentAction.monster.status) {
+    opponentSpeed = Math.floor(opponentSpeed * getStatusEffect(opponentAction.monster.status).speedModifier);
+  }
 
   if (playerSpeed !== opponentSpeed) {
     return playerSpeed > opponentSpeed

--- a/src/engine/map/encounter.ts
+++ b/src/engine/map/encounter.ts
@@ -1,5 +1,6 @@
-import type { MonsterInstance } from "@/types";
+import type { MonsterInstance, MonsterSpecies, MoveDefinition } from "@/types";
 import type { MapDefinition, EncounterEntry } from "./map-data";
+import { calcAllStats } from "@/engine/monster/stats";
 
 /**
  * エンカウントシステム (#34)
@@ -57,35 +58,59 @@ export function rollLevel(
   return minLevel + Math.floor(random() * (maxLevel - minLevel + 1));
 }
 
+/** 種族データを引けるリゾルバ */
+export type SpeciesResolver = (speciesId: string) => MonsterSpecies;
+export type MoveResolver = (moveId: string) => MoveDefinition;
+
 /**
  * 野生モンスターのインスタンスを生成
  * @param entry 出現テーブルエントリ
+ * @param speciesResolver 種族データリゾルバ
+ * @param moveResolver 技データリゾルバ
  * @param random 乱数関数（テスト用DI）
  */
 export function generateWildMonster(
   entry: EncounterEntry,
+  speciesResolver: SpeciesResolver,
+  moveResolver: MoveResolver,
   random: () => number = Math.random,
 ): MonsterInstance {
   const level = rollLevel(entry.minLevel, entry.maxLevel, random);
+  const species = speciesResolver(entry.speciesId);
 
   // 野生モンスターのIVはランダム (0-31)
   const rollIv = () => Math.floor(random() * 32);
+
+  const ivs = {
+    hp: rollIv(),
+    atk: rollIv(),
+    def: rollIv(),
+    spAtk: rollIv(),
+    spDef: rollIv(),
+    speed: rollIv(),
+  };
+  const evs = { hp: 0, atk: 0, def: 0, spAtk: 0, spDef: 0, speed: 0 };
+
+  // maxHpを計算してcurrentHpに設定
+  const maxHp = calcAllStats(species.baseStats, ivs, evs, level).hp;
+
+  // learnsetから現在レベルまでの技を最大4つ設定
+  const learnableMoves = species.learnset
+    .filter((e) => e.level <= level)
+    .slice(-4); // 最新の4つを取得
+  const moves = learnableMoves.map((e) => {
+    const moveDef = moveResolver(e.moveId);
+    return { moveId: e.moveId, currentPp: moveDef.pp };
+  });
 
   return {
     speciesId: entry.speciesId,
     level,
     exp: 0,
-    ivs: {
-      hp: rollIv(),
-      atk: rollIv(),
-      def: rollIv(),
-      spAtk: rollIv(),
-      spDef: rollIv(),
-      speed: rollIv(),
-    },
-    evs: { hp: 0, atk: 0, def: 0, spAtk: 0, spDef: 0, speed: 0 },
-    currentHp: 0, // 後でmaxHpCalcで設定する
-    moves: [], // 後でspeciesのlearnsetから設定する
+    ivs,
+    evs,
+    currentHp: maxHp,
+    moves,
     status: null,
   };
 }
@@ -96,6 +121,8 @@ export function generateWildMonster(
  */
 export function processEncounter(
   map: MapDefinition,
+  speciesResolver: SpeciesResolver,
+  moveResolver: MoveResolver,
   random: () => number = Math.random,
 ): MonsterInstance | null {
   if (!shouldEncounter(map.encounterRate, random)) return null;
@@ -103,5 +130,5 @@ export function processEncounter(
   const entry = rollEncounter(map.encounters, random);
   if (!entry) return null;
 
-  return generateWildMonster(entry, random);
+  return generateWildMonster(entry, speciesResolver, moveResolver, random);
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,7 +3,7 @@
  */
 
 /** ゲームのトップレベル状態 */
-export type GameState = "title" | "overworld" | "battle" | "menu" | "dialogue" | "cutscene";
+export type GamePhase = "title" | "overworld" | "battle" | "menu" | "dialogue" | "cutscene";
 
 /** 一意な識別子 */
 export type MonsterId = string;


### PR DESCRIPTION
## Summary
- **7件のクリティカルバグ修正** (B1-B7): 麻痺素早さ未適用、逃走試行回数未カウント、わるあがき未実装、交代バリデーション欠如、型名衝突、野生モンスターHP/技初期化不備、stale closure
- **2件の設計改善** (D2, D5): バトル中アイテム使用ハンドリング、PP回復アイテム対応
- **13件の新規テスト追加** (T1-T6): 全バグ修正の検証テスト + 経験値境界テスト

## 修正対象ファイル (10ファイル)
| ファイル | 修正 |
|---------|------|
| `src/engine/battle/turn-order.ts` | B1: 麻痺素早さ修正子 |
| `src/engine/battle/state-machine.ts` | B2: escapeAttempts追加 |
| `src/engine/battle/engine.ts` | B2, B3, B4, D2 |
| `src/engine/battle/move-executor.ts` | B3: executeStruggle() |
| `src/types/index.ts` | B5: GameState→GamePhase |
| `src/engine/map/encounter.ts` | B6: HP/技初期化 |
| `src/components/screens/StarterSelect.tsx` | B7: stale closure |
| `src/engine/item/bag.ts` | D5: heal_pp |
| `src/engine/battle/__tests__/engine.test.ts` | T1-T4, T6 |
| `src/engine/map/__tests__/encounter.test.ts` | T5 |

## Test plan
- [x] `tsc --noEmit` — 型エラーなし
- [x] `eslint` — エラー/警告なし
- [x] `vitest run` — 163テスト全パス（既存150 + 新規13）
- [x] `next build` — ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)