### PR TITLE
feat: Species/Monster型定義の拡充

### DIFF
--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -29,9 +29,11 @@ const STARTERS: StarterOption[] = [
 
 function createStarterInstance(speciesId: string): MonsterInstance {
   return {
+    uid: crypto.randomUUID(),
     speciesId,
     level: 5,
     exp: 0,
+    nature: "hardy",
     ivs: { hp: 20, atk: 20, def: 20, spAtk: 20, spDef: 20, speed: 20 },
     evs: { hp: 0, atk: 0, def: 0, spAtk: 0, spDef: 0, speed: 0 },
     currentHp: 20,

--- a/src/engine/battle/__tests__/damage.test.ts
+++ b/src/engine/battle/__tests__/damage.test.ts
@@ -5,9 +5,11 @@ import type { MonsterInstance, MonsterSpecies, MoveDefinition } from "@/types";
 /** テスト用ヘルパー: デフォルトのモンスターインスタンスを生成 */
 function createMonster(overrides?: Partial<MonsterInstance>): MonsterInstance {
   return {
+    uid: "test-damage",
     speciesId: "test-monster",
     level: 50,
     exp: 0,
+    nature: "hardy",
     ivs: { hp: 31, atk: 31, def: 31, spAtk: 31, spDef: 31, speed: 31 },
     evs: { hp: 0, atk: 0, def: 0, spAtk: 0, spDef: 0, speed: 0 },
     currentHp: 100,
@@ -24,6 +26,8 @@ function createSpecies(overrides?: Partial<MonsterSpecies>): MonsterSpecies {
     name: "テストモンスター",
     types: ["normal"],
     baseStats: { hp: 80, atk: 80, def: 80, spAtk: 80, spDef: 80, speed: 80 },
+    baseExpYield: 80,
+    expGroup: "medium_fast",
     learnset: [],
     ...overrides,
   };

--- a/src/engine/battle/__tests__/engine.test.ts
+++ b/src/engine/battle/__tests__/engine.test.ts
@@ -10,6 +10,8 @@ const species: Record<string, MonsterSpecies> = {
     name: "ヒノコン",
     types: ["fire"],
     baseStats: { hp: 45, atk: 60, def: 50, spAtk: 80, spDef: 60, speed: 70 },
+    baseExpYield: 62,
+    expGroup: "medium_fast",
     learnset: [{ level: 1, moveId: "ember" }],
   },
   "water-starter": {
@@ -17,6 +19,8 @@ const species: Record<string, MonsterSpecies> = {
     name: "ミズリン",
     types: ["water"],
     baseStats: { hp: 50, atk: 50, def: 65, spAtk: 70, spDef: 70, speed: 60 },
+    baseExpYield: 63,
+    expGroup: "medium_fast",
     learnset: [{ level: 1, moveId: "water-gun" }],
   },
   "grass-starter": {
@@ -24,6 +28,8 @@ const species: Record<string, MonsterSpecies> = {
     name: "クサネコ",
     types: ["grass"],
     baseStats: { hp: 55, atk: 55, def: 60, spAtk: 65, spDef: 65, speed: 50 },
+    baseExpYield: 64,
+    expGroup: "medium_fast",
     learnset: [{ level: 1, moveId: "vine-whip" }],
   },
 };
@@ -33,6 +39,8 @@ const ghostSpecies: MonsterSpecies = {
   name: "ユウレイ",
   types: ["ghost"],
   baseStats: { hp: 60, atk: 60, def: 60, spAtk: 60, spDef: 60, speed: 60 },
+  baseExpYield: 60,
+  expGroup: "medium_fast",
   learnset: [{ level: 1, moveId: "shadow-ball" }],
 };
 
@@ -41,6 +49,8 @@ const normalSpecies: MonsterSpecies = {
   name: "ノーマン",
   types: ["normal"],
   baseStats: { hp: 80, atk: 80, def: 80, spAtk: 80, spDef: 80, speed: 80 },
+  baseExpYield: 80,
+  expGroup: "medium_fast",
   learnset: [{ level: 1, moveId: "tackle" }],
 };
 
@@ -130,9 +140,11 @@ const moveResolver = (id: string) => moves[id];
 function createInstance(speciesId: string, level: number = 50): MonsterInstance {
   const sp = allSpecies[speciesId];
   return {
+    uid: `test-${speciesId}-${level}`,
     speciesId,
     level,
     exp: level * level * level,
+    nature: "hardy",
     ivs: { hp: 15, atk: 15, def: 15, spAtk: 15, spDef: 15, speed: 15 },
     evs: { hp: 0, atk: 0, def: 0, spAtk: 0, spDef: 0, speed: 0 },
     currentHp: 200,

--- a/src/engine/battle/engine.ts
+++ b/src/engine/battle/engine.ts
@@ -289,7 +289,8 @@ export class BattleEngine {
         this.opponentActive.level,
         this.state.battleType === "trainer",
       );
-      const { levelsGained } = grantExp(this.playerActive, expGain);
+      const playerSpeciesForExp = this.speciesResolver(this.playerActive.speciesId);
+      const { levelsGained } = grantExp(this.playerActive, expGain, playerSpeciesForExp.expGroup);
       const playerSpecies = this.speciesResolver(this.playerActive.speciesId);
       this.state.messages.push(`${playerSpecies.name}は${expGain}の経験値を得た！`);
       if (levelsGained > 0) {

--- a/src/engine/battle/experience.ts
+++ b/src/engine/battle/experience.ts
@@ -1,43 +1,52 @@
-import type { MonsterInstance, MonsterSpecies } from "@/types";
+import type { MonsterInstance, MonsterSpecies, ExpGroup } from "@/types";
 
 /**
- * 経験値計算（簡易版）
- * 基本式: (baseExp * defeatedLevel) / 7
- *
- * baseExp は倒したモンスターの種族による基礎経験値
- * （現時点では種族値合計 / 4 で代用）
+ * 経験値計算
+ * 基本式: (baseExpYield * defeatedLevel) / 7
  */
 export function calcExpGain(
   defeatedSpecies: MonsterSpecies,
   defeatedLevel: number,
   isTrainerBattle: boolean,
 ): number {
-  const { hp, atk, def, spAtk, spDef, speed } = defeatedSpecies.baseStats;
-  const baseExp = Math.floor((hp + atk + def + spAtk + spDef + speed) / 4);
+  const baseExp = defeatedSpecies.baseExpYield;
   const trainerBonus = isTrainerBattle ? 1.5 : 1;
   return Math.floor((baseExp * defeatedLevel * trainerBonus) / 7);
 }
 
 /**
- * レベルアップに必要な累計経験値（中速グループ）
- * 公式: n^3
+ * レベルアップに必要な累計経験値
+ * @param level 目標レベル
+ * @param group 経験値グループ（省略時は medium_fast）
  */
-export function expForLevel(level: number): number {
-  return level * level * level;
+export function expForLevel(level: number, group: ExpGroup = "medium_fast"): number {
+  const n = level;
+  switch (group) {
+    case "fast":
+      return Math.floor(0.8 * n * n * n);
+    case "medium_fast":
+      return n * n * n;
+    case "medium_slow":
+      return Math.floor(1.2 * n * n * n - 15 * n * n + 100 * n - 140);
+    case "slow":
+      return Math.floor(1.25 * n * n * n);
+  }
 }
 
 /**
  * 経験値を付与してレベルアップを処理
+ * @param expGroup 経験値グループ（省略時は medium_fast）
  * @returns レベルアップした場合のレベル差（0=レベルアップなし）
  */
 export function grantExp(
   monster: MonsterInstance,
   expGain: number,
+  expGroup: ExpGroup = "medium_fast",
 ): { levelsGained: number; newLevel: number } {
   monster.exp += expGain;
   let levelsGained = 0;
 
-  while (monster.level < 100 && monster.exp >= expForLevel(monster.level + 1)) {
+  while (monster.level < 100 && monster.exp >= expForLevel(monster.level + 1, expGroup)) {
     monster.level++;
     levelsGained++;
   }

--- a/src/engine/capture/__tests__/capture-flow.test.ts
+++ b/src/engine/capture/__tests__/capture-flow.test.ts
@@ -5,9 +5,11 @@ import type { MonsterInstance } from "@/types";
 
 function createDummyMonster(id: string = "wild"): MonsterInstance {
   return {
+    uid: `test-${id}`,
     speciesId: id,
     level: 10,
     exp: 1000,
+    nature: "hardy",
     ivs: { hp: 15, atk: 15, def: 15, spAtk: 15, spDef: 15, speed: 15 },
     evs: { hp: 0, atk: 0, def: 0, spAtk: 0, spDef: 0, speed: 0 },
     currentHp: 20,

--- a/src/engine/item/__tests__/bag.test.ts
+++ b/src/engine/item/__tests__/bag.test.ts
@@ -11,9 +11,11 @@ import type { ItemDefinition, MonsterInstance } from "@/types";
 
 function createDummyMonster(hp: number = 30): MonsterInstance {
   return {
+    uid: "test-bag",
     speciesId: "test",
     level: 10,
     exp: 1000,
+    nature: "hardy",
     ivs: { hp: 15, atk: 15, def: 15, spAtk: 15, spDef: 15, speed: 15 },
     evs: { hp: 0, atk: 0, def: 0, spAtk: 0, spDef: 0, speed: 0 },
     currentHp: hp,

--- a/src/engine/map/__tests__/encounter.test.ts
+++ b/src/engine/map/__tests__/encounter.test.ts
@@ -22,6 +22,8 @@ const testSpecies: Record<string, MonsterSpecies> = {
     name: "ラッタ",
     types: ["normal"],
     baseStats: { hp: 30, atk: 56, def: 35, spAtk: 25, spDef: 35, speed: 72 },
+    baseExpYield: 51,
+    expGroup: "medium_fast",
     learnset: [
       { level: 1, moveId: "tackle" },
       { level: 4, moveId: "tail-whip" },
@@ -33,6 +35,8 @@ const testSpecies: Record<string, MonsterSpecies> = {
     name: "ポッポ",
     types: ["normal", "flying"],
     baseStats: { hp: 40, atk: 45, def: 40, spAtk: 35, spDef: 35, speed: 56 },
+    baseExpYield: 50,
+    expGroup: "medium_slow",
     learnset: [
       { level: 1, moveId: "tackle" },
       { level: 5, moveId: "gust" },
@@ -43,6 +47,8 @@ const testSpecies: Record<string, MonsterSpecies> = {
     name: "ピカチュウ",
     types: ["electric"],
     baseStats: { hp: 35, atk: 55, def: 40, spAtk: 50, spDef: 50, speed: 90 },
+    baseExpYield: 112,
+    expGroup: "medium_fast",
     learnset: [
       { level: 1, moveId: "thunder-shock" },
       { level: 4, moveId: "tail-whip" },

--- a/src/engine/map/__tests__/healing.test.ts
+++ b/src/engine/map/__tests__/healing.test.ts
@@ -4,9 +4,11 @@ import type { MonsterInstance, MoveDefinition } from "@/types";
 
 function createDummyMonster(hp: number = 30): MonsterInstance {
   return {
+    uid: "test-healing",
     speciesId: "test",
     level: 10,
     exp: 1000,
+    nature: "hardy",
     ivs: { hp: 15, atk: 15, def: 15, spAtk: 15, spDef: 15, speed: 15 },
     evs: { hp: 0, atk: 0, def: 0, spAtk: 0, spDef: 0, speed: 0 },
     currentHp: hp,

--- a/src/engine/map/encounter.ts
+++ b/src/engine/map/encounter.ts
@@ -1,6 +1,8 @@
 import type { MonsterInstance, MonsterSpecies, MoveDefinition } from "@/types";
 import type { MapDefinition, EncounterEntry } from "./map-data";
 import { calcAllStats } from "@/engine/monster/stats";
+import { randomNature } from "@/engine/monster/nature";
+import { generateUid } from "@/engine/monster/uid";
 
 /**
  * エンカウントシステム (#34)
@@ -104,9 +106,11 @@ export function generateWildMonster(
   });
 
   return {
+    uid: generateUid(),
     speciesId: entry.speciesId,
     level,
     exp: 0,
+    nature: randomNature(random),
     ivs,
     evs,
     currentHp: maxHp,

--- a/src/engine/monster/__tests__/evolution.test.ts
+++ b/src/engine/monster/__tests__/evolution.test.ts
@@ -4,9 +4,11 @@ import type { MonsterInstance, MonsterSpecies } from "@/types";
 
 function createDummyMonster(level: number = 10, currentHp: number = 30): MonsterInstance {
   return {
+    uid: `test-charmander-${level}`,
     speciesId: "charmander",
     level,
     exp: 1000,
+    nature: "hardy",
     ivs: { hp: 15, atk: 15, def: 15, spAtk: 15, spDef: 15, speed: 15 },
     evs: { hp: 0, atk: 0, def: 0, spAtk: 0, spDef: 0, speed: 0 },
     currentHp,
@@ -20,8 +22,10 @@ const charmander: MonsterSpecies = {
   name: "ヒトカゲ",
   types: ["fire"],
   baseStats: { hp: 39, atk: 52, def: 43, spAtk: 60, spDef: 50, speed: 65 },
+  baseExpYield: 62,
+  expGroup: "medium_fast",
   learnset: [],
-  evolvesTo: { id: "charmeleon", level: 16 },
+  evolvesTo: [{ id: "charmeleon", level: 16 }],
 };
 
 const charmeleon: MonsterSpecies = {
@@ -29,8 +33,10 @@ const charmeleon: MonsterSpecies = {
   name: "リザード",
   types: ["fire"],
   baseStats: { hp: 58, atk: 64, def: 58, spAtk: 80, spDef: 65, speed: 80 },
+  baseExpYield: 142,
+  expGroup: "medium_fast",
   learnset: [],
-  evolvesTo: { id: "charizard", level: 36 },
+  evolvesTo: [{ id: "charizard", level: 36 }],
 };
 
 const noEvoSpecies: MonsterSpecies = {
@@ -38,6 +44,8 @@ const noEvoSpecies: MonsterSpecies = {
   name: "ピカチュウ",
   types: ["electric"],
   baseStats: { hp: 35, atk: 55, def: 40, spAtk: 50, spDef: 50, speed: 90 },
+  baseExpYield: 112,
+  expGroup: "medium_fast",
   learnset: [],
 };
 

--- a/src/engine/monster/__tests__/moves.test.ts
+++ b/src/engine/monster/__tests__/moves.test.ts
@@ -4,9 +4,11 @@ import type { MonsterSpecies, MonsterInstance, MoveDefinition } from "@/types";
 
 function createDummyMonster(moves: { moveId: string; currentPp: number }[] = []): MonsterInstance {
   return {
+    uid: "test-moves",
     speciesId: "test",
     level: 10,
     exp: 1000,
+    nature: "hardy",
     ivs: { hp: 15, atk: 15, def: 15, spAtk: 15, spDef: 15, speed: 15 },
     evs: { hp: 0, atk: 0, def: 0, spAtk: 0, spDef: 0, speed: 0 },
     currentHp: 30,
@@ -53,6 +55,8 @@ const dummySpecies: MonsterSpecies = {
   name: "テストモン",
   types: ["fire"],
   baseStats: { hp: 45, atk: 60, def: 40, spAtk: 70, spDef: 50, speed: 65 },
+  baseExpYield: 62,
+  expGroup: "medium_fast",
   learnset: [
     { level: 1, moveId: "tackle" },
     { level: 5, moveId: "ember" },

--- a/src/engine/monster/__tests__/party.test.ts
+++ b/src/engine/monster/__tests__/party.test.ts
@@ -12,9 +12,11 @@ import type { MonsterInstance, MoveDefinition } from "@/types";
 
 function createDummyMonster(id: string = "test"): MonsterInstance {
   return {
+    uid: `test-${id}`,
     speciesId: id,
     level: 10,
     exp: 1000,
+    nature: "hardy",
     ivs: { hp: 15, atk: 15, def: 15, spAtk: 15, spDef: 15, speed: 15 },
     evs: { hp: 0, atk: 0, def: 0, spAtk: 0, spDef: 0, speed: 0 },
     currentHp: 30,

--- a/src/engine/monster/evolution.ts
+++ b/src/engine/monster/evolution.ts
@@ -2,13 +2,15 @@ import type { MonsterInstance, MonsterSpecies } from "@/types";
 import { calcHp } from "./stats";
 
 /**
- * 進化条件をチェック
+ * 進化条件をチェック（配列をイテレートし、条件を満たす最初の進化先を返す）
  * @returns 進化先のspeciesId、または null（進化しない場合）
  */
 export function checkEvolution(monster: MonsterInstance, species: MonsterSpecies): string | null {
-  if (!species.evolvesTo) return null;
-  if (monster.level >= species.evolvesTo.level) {
-    return species.evolvesTo.id;
+  if (!species.evolvesTo || species.evolvesTo.length === 0) return null;
+  for (const evo of species.evolvesTo) {
+    if (monster.level >= evo.level) {
+      return evo.id;
+    }
   }
   return null;
 }

--- a/src/engine/monster/nature.ts
+++ b/src/engine/monster/nature.ts
@@ -1,0 +1,67 @@
+import type { NatureId } from "@/types";
+
+/** ステータス名（HP除く） */
+type StatName = "atk" | "def" | "spAtk" | "spDef" | "speed";
+
+/** 性格による上昇/下降ステータスのマッピング */
+const NATURE_TABLE: Record<NatureId, { up: StatName | null; down: StatName | null }> = {
+  // 無補正（対角線）
+  hardy:  { up: null, down: null },
+  docile: { up: null, down: null },
+  serious: { up: null, down: null },
+  bashful: { up: null, down: null },
+  quirky: { up: null, down: null },
+  // atk↑
+  lonely:  { up: "atk", down: "def" },
+  brave:   { up: "atk", down: "speed" },
+  adamant: { up: "atk", down: "spAtk" },
+  naughty: { up: "atk", down: "spDef" },
+  // def↑
+  bold:    { up: "def", down: "atk" },
+  relaxed: { up: "def", down: "speed" },
+  impish:  { up: "def", down: "spAtk" },
+  lax:     { up: "def", down: "spDef" },
+  // speed↑
+  timid:   { up: "speed", down: "atk" },
+  hasty:   { up: "speed", down: "def" },
+  jolly:   { up: "speed", down: "spAtk" },
+  naive:   { up: "speed", down: "spDef" },
+  // spAtk↑
+  modest:  { up: "spAtk", down: "atk" },
+  mild:    { up: "spAtk", down: "def" },
+  quiet:   { up: "spAtk", down: "speed" },
+  rash:    { up: "spAtk", down: "spDef" },
+  // spDef↑
+  calm:    { up: "spDef", down: "atk" },
+  gentle:  { up: "spDef", down: "def" },
+  sassy:   { up: "spDef", down: "speed" },
+  careful: { up: "spDef", down: "spAtk" },
+};
+
+/** 全25種類の性格IDリスト */
+export const ALL_NATURES: NatureId[] = Object.keys(NATURE_TABLE) as NatureId[];
+
+/**
+ * 性格によるステータス補正値を返す
+ * 上昇ステータスは1.1、下降ステータスは0.9、それ以外は1.0
+ */
+export function getNatureModifiers(nature: NatureId): Record<StatName, number> {
+  const { up, down } = NATURE_TABLE[nature];
+  const mods: Record<StatName, number> = {
+    atk: 1.0,
+    def: 1.0,
+    spAtk: 1.0,
+    spDef: 1.0,
+    speed: 1.0,
+  };
+  if (up) mods[up] = 1.1;
+  if (down) mods[down] = 0.9;
+  return mods;
+}
+
+/**
+ * ランダムに性格を選択
+ */
+export function randomNature(random: () => number = Math.random): NatureId {
+  return ALL_NATURES[Math.floor(random() * ALL_NATURES.length)];
+}

--- a/src/engine/monster/stats.ts
+++ b/src/engine/monster/stats.ts
@@ -1,4 +1,5 @@
-import type { BaseStats, IVs, EVs } from "@/types";
+import type { BaseStats, IVs, EVs, NatureId } from "@/types";
+import { getNatureModifiers } from "./nature";
 
 /**
  * HPの実数値を計算
@@ -27,19 +28,22 @@ export function calcStat(
 
 /**
  * 全ステータスの実数値を一括計算
+ * @param nature 性格（省略時は補正なし）
  */
 export function calcAllStats(
   baseStats: BaseStats,
   ivs: IVs,
   evs: EVs,
   level: number,
+  nature?: NatureId,
 ): BaseStats & { hp: number } {
+  const mods = nature ? getNatureModifiers(nature) : undefined;
   return {
     hp: calcHp(baseStats.hp, ivs.hp, evs.hp, level),
-    atk: calcStat(baseStats.atk, ivs.atk, evs.atk, level),
-    def: calcStat(baseStats.def, ivs.def, evs.def, level),
-    spAtk: calcStat(baseStats.spAtk, ivs.spAtk, evs.spAtk, level),
-    spDef: calcStat(baseStats.spDef, ivs.spDef, evs.spDef, level),
-    speed: calcStat(baseStats.speed, ivs.speed, evs.speed, level),
+    atk: calcStat(baseStats.atk, ivs.atk, evs.atk, level, mods?.atk),
+    def: calcStat(baseStats.def, ivs.def, evs.def, level, mods?.def),
+    spAtk: calcStat(baseStats.spAtk, ivs.spAtk, evs.spAtk, level, mods?.spAtk),
+    spDef: calcStat(baseStats.spDef, ivs.spDef, evs.spDef, level, mods?.spDef),
+    speed: calcStat(baseStats.speed, ivs.speed, evs.speed, level, mods?.speed),
   };
 }

--- a/src/engine/monster/uid.ts
+++ b/src/engine/monster/uid.ts
@@ -1,0 +1,7 @@
+/**
+ * モンスター個体の一意識別子を生成
+ * Web Crypto API を使用（ブラウザ/Node.js 両対応）
+ */
+export function generateUid(): string {
+  return crypto.randomUUID();
+}

--- a/src/engine/state/__tests__/game-state.test.ts
+++ b/src/engine/state/__tests__/game-state.test.ts
@@ -4,9 +4,11 @@ import type { MonsterInstance } from "@/types";
 
 function createDummyMonster(): MonsterInstance {
   return {
+    uid: "test-starter",
     speciesId: "fire-starter",
     level: 5,
     exp: 0,
+    nature: "hardy",
     ivs: { hp: 20, atk: 20, def: 20, spAtk: 20, spDef: 20, speed: 20 },
     evs: { hp: 0, atk: 0, def: 0, spAtk: 0, spDef: 0, speed: 0 },
     currentHp: 20,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,17 @@ export type MoveId = string;
 export type ItemId = string;
 export type MapId = string;
 
+/** 性格ID（25種類） */
+export type NatureId =
+  | "hardy" | "lonely" | "brave" | "adamant" | "naughty"
+  | "bold" | "docile" | "relaxed" | "impish" | "lax"
+  | "timid" | "hasty" | "serious" | "jolly" | "naive"
+  | "modest" | "mild" | "quiet" | "bashful" | "rash"
+  | "calm" | "gentle" | "sassy" | "careful" | "quirky";
+
+/** 経験値グループ */
+export type ExpGroup = "fast" | "medium_fast" | "medium_slow" | "slow";
+
 /** タイプID */
 export type TypeId =
   | "normal"
@@ -54,16 +65,20 @@ export interface MonsterSpecies {
   name: string;
   types: [TypeId] | [TypeId, TypeId];
   baseStats: BaseStats;
+  baseExpYield: number;
+  expGroup: ExpGroup;
   learnset: { level: number; moveId: MoveId }[];
-  evolvesTo?: { id: MonsterId; level: number };
+  evolvesTo?: { id: MonsterId; level: number; condition?: string }[];
 }
 
 /** 個体としてのモンスター */
 export interface MonsterInstance {
+  uid: string;
   speciesId: MonsterId;
   nickname?: string;
   level: number;
   exp: number;
+  nature: NatureId;
   ivs: IVs;
   evs: EVs;
   currentHp: number;


### PR DESCRIPTION
## Summary
- `NatureId`（性格25種）、`MonsterInstance.uid`、`MonsterInstance.nature`、`MonsterSpecies.baseExpYield`、`MonsterSpecies.expGroup`、`evolvesTo`配列化の6項目を実装
- 性格補正ステータス計算、経験値グループ別カーブ（fast/medium_fast/medium_slow/slow）、分岐進化対応のロジックを追加
- 全163テスト、型チェック、lint、ビルドがパス

## Test plan
- [x] `bun run type-check` — 型エラーなし
- [x] `bun run lint` — ESLintエラーなし
- [x] `bun run test` — 163テスト全パス
- [x] `bun run build` — Next.jsビルド成功

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)