### PR TITLE
fix: 監査で発見した経験値バグ+性格補正未接続を修正

### DIFF
--- a/src/engine/battle/damage.ts
+++ b/src/engine/battle/damage.ts
@@ -42,12 +42,14 @@ export function calculateDamage(ctx: DamageContext): DamageResult {
     attacker.ivs,
     attacker.evs,
     attacker.level,
+    attacker.nature,
   );
   const defenderStats = calcAllStats(
     defenderSpecies.baseStats,
     defender.ivs,
     defender.evs,
     defender.level,
+    defender.nature,
   );
 
   // 物理 or 特殊に応じてA/Dを選択

--- a/src/engine/battle/engine.ts
+++ b/src/engine/battle/engine.ts
@@ -189,6 +189,7 @@ export class BattleEngine {
         action.monster.ivs,
         action.monster.evs,
         action.monster.level,
+        action.monster.nature,
       ).hp;
       const result = executeStruggle(
         action.monster,
@@ -233,12 +234,14 @@ export class BattleEngine {
       this.playerActive.ivs,
       this.playerActive.evs,
       this.playerActive.level,
+      this.playerActive.nature,
     ).speed;
     const opponentSpeed = calcAllStats(
       opponentSpecies.baseStats,
       this.opponentActive.ivs,
       this.opponentActive.evs,
       this.opponentActive.level,
+      this.opponentActive.nature,
     ).speed;
 
     const escapeChance = Math.min(
@@ -353,7 +356,7 @@ export class BattleEngine {
     const applyToMonster = (monster: MonsterInstance) => {
       if (!monster.status || monster.currentHp <= 0) return;
       const species = this.speciesResolver(monster.speciesId);
-      const maxHp = calcAllStats(species.baseStats, monster.ivs, monster.evs, monster.level).hp;
+      const maxHp = calcAllStats(species.baseStats, monster.ivs, monster.evs, monster.level, monster.nature).hp;
       const hpBefore = monster.currentHp;
       monster.currentHp = applyStatusDamage(monster, maxHp);
       if (monster.currentHp < hpBefore) {

--- a/src/engine/battle/experience.ts
+++ b/src/engine/battle/experience.ts
@@ -27,7 +27,7 @@ export function expForLevel(level: number, group: ExpGroup = "medium_fast"): num
     case "medium_fast":
       return n * n * n;
     case "medium_slow":
-      return Math.floor(1.2 * n * n * n - 15 * n * n + 100 * n - 140);
+      return Math.max(0, Math.floor(1.2 * n * n * n - 15 * n * n + 100 * n - 140));
     case "slow":
       return Math.floor(1.25 * n * n * n);
   }

--- a/src/engine/battle/turn-order.ts
+++ b/src/engine/battle/turn-order.ts
@@ -53,6 +53,7 @@ export function determineTurnOrder(
     playerAction.monster.ivs,
     playerAction.monster.evs,
     playerAction.monster.level,
+    playerAction.monster.nature,
   ).speed;
   if (playerAction.monster.status) {
     playerSpeed = Math.floor(playerSpeed * getStatusEffect(playerAction.monster.status).speedModifier);
@@ -63,6 +64,7 @@ export function determineTurnOrder(
     opponentAction.monster.ivs,
     opponentAction.monster.evs,
     opponentAction.monster.level,
+    opponentAction.monster.nature,
   ).speed;
   if (opponentAction.monster.status) {
     opponentSpeed = Math.floor(opponentSpeed * getStatusEffect(opponentAction.monster.status).speedModifier);

--- a/src/engine/map/encounter.ts
+++ b/src/engine/map/encounter.ts
@@ -93,8 +93,10 @@ export function generateWildMonster(
   };
   const evs = { hp: 0, atk: 0, def: 0, spAtk: 0, spDef: 0, speed: 0 };
 
+  const nature = randomNature(random);
+
   // maxHpを計算してcurrentHpに設定
-  const maxHp = calcAllStats(species.baseStats, ivs, evs, level).hp;
+  const maxHp = calcAllStats(species.baseStats, ivs, evs, level, nature).hp;
 
   // learnsetから現在レベルまでの技を最大4つ設定
   const learnableMoves = species.learnset
@@ -110,7 +112,7 @@ export function generateWildMonster(
     speciesId: entry.speciesId,
     level,
     exp: 0,
-    nature: randomNature(random),
+    nature,
     ivs,
     evs,
     currentHp: maxHp,


### PR DESCRIPTION
## Summary
- `expForLevel()` で `medium_slow` グループがレベル1で負の値（-54）を返すバグを修正（`Math.max(0, ...)` でクランプ）
- `calcAllStats()` の全呼び出し箇所（6箇所）に `monster.nature` を渡し、性格補正を実際のバトル計算に反映

## 修正箇所
| ファイル | 修正内容 |
|---------|---------|
| `experience.ts` | medium_slow の負値を `max(0)` でクランプ |
| `damage.ts` | 攻撃側/防御側ステータスに性格補正適用 |
| `turn-order.ts` | 素早さ比較に性格補正適用 |
| `engine.ts` | わるあがきmaxHP・逃走速度・ターン終了maxHPに性格補正適用 |
| `encounter.ts` | 野生モンスター生成時のmaxHP計算に性格補正適用 + randomNature重複呼び出し修正 |

## Test plan
- [x] `bun run type-check` — 型エラーなし
- [x] `bun run lint` — ESLintエラーなし
- [x] `bun run test` — 163テスト全パス
- [x] `bun run build` — ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)