### PR TITLE
feat: セーブ/ロードシステムの設計と実装

### DIFF
--- a/src/engine/state/__tests__/save-data.test.ts
+++ b/src/engine/state/__tests__/save-data.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  serializeGameState,
+  deserializeGameState,
+  validateSaveData,
+  saveToSlot,
+  loadFromSlot,
+  deleteSlot,
+  listSaveSlots,
+  saveGame,
+  loadGame,
+  SAVE_DATA_VERSION,
+  MAX_SAVE_SLOTS,
+} from "../save-data";
+import type { GameState } from "../game-state";
+import type { MonsterInstance } from "@/types";
+
+function createTestMonster(): MonsterInstance {
+  return {
+    uid: "test-uid-001",
+    speciesId: "fire-starter",
+    level: 15,
+    exp: 3375,
+    nature: "adamant",
+    ivs: { hp: 20, atk: 25, def: 15, spAtk: 10, spDef: 20, speed: 18 },
+    evs: { hp: 0, atk: 10, def: 0, spAtk: 0, spDef: 0, speed: 0 },
+    currentHp: 45,
+    moves: [
+      { moveId: "tackle", currentPp: 30 },
+      { moveId: "ember", currentPp: 20 },
+    ],
+    status: null,
+  };
+}
+
+function createTestGameState(): GameState {
+  return {
+    screen: "overworld",
+    player: {
+      name: "サトシ",
+      money: 5000,
+      badges: ["badge1"],
+      partyState: {
+        party: [createTestMonster()],
+        boxes: Array.from({ length: 8 }, () => []),
+      },
+      bag: { items: [{ itemId: "potion", quantity: 3 }] },
+      pokedexSeen: new Set(["fire-starter", "water-starter"]),
+      pokedexCaught: new Set(["fire-starter"]),
+    },
+    overworld: {
+      currentMapId: "route-1",
+      playerX: 5,
+      playerY: 10,
+      direction: "down",
+    },
+    storyFlags: { intro_done: true },
+  };
+}
+
+// localStorage モック
+const storage = new Map<string, string>();
+beforeEach(() => {
+  storage.clear();
+  Object.defineProperty(globalThis, "localStorage", {
+    value: {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => storage.set(key, value),
+      removeItem: (key: string) => storage.delete(key),
+      clear: () => storage.clear(),
+    },
+    writable: true,
+  });
+});
+
+describe("セーブデータ構造", () => {
+  describe("serializeGameState", () => {
+    it("GameStateをSaveDataに変換できる", () => {
+      const state = createTestGameState();
+      const saveData = serializeGameState(state, 3600);
+
+      expect(saveData).not.toBeNull();
+      expect(saveData!.version).toBe(SAVE_DATA_VERSION);
+      expect(saveData!.playTime).toBe(3600);
+      expect(typeof saveData!.savedAt).toBe("string");
+    });
+
+    it("Set がstring[]に変換される", () => {
+      const state = createTestGameState();
+      const saveData = serializeGameState(state)!;
+
+      expect(Array.isArray(saveData.state.player.pokedexSeen)).toBe(true);
+      expect(saveData.state.player.pokedexSeen).toContain("fire-starter");
+      expect(saveData.state.player.pokedexSeen).toContain("water-starter");
+      expect(Array.isArray(saveData.state.player.pokedexCaught)).toBe(true);
+      expect(saveData.state.player.pokedexCaught).toContain("fire-starter");
+    });
+
+    it("playerがnullの場合nullを返す", () => {
+      const state: GameState = {
+        screen: "title",
+        player: null,
+        overworld: null,
+        storyFlags: {},
+      };
+      expect(serializeGameState(state)).toBeNull();
+    });
+
+    it("モンスターデータが正しくシリアライズされる", () => {
+      const state = createTestGameState();
+      const saveData = serializeGameState(state)!;
+      const monster = saveData.state.player.partyState.party[0];
+
+      expect(monster.uid).toBe("test-uid-001");
+      expect(monster.nature).toBe("adamant");
+      expect(monster.level).toBe(15);
+      expect(monster.moves).toHaveLength(2);
+    });
+  });
+
+  describe("deserializeGameState", () => {
+    it("SaveDataをGameStateに復元できる", () => {
+      const state = createTestGameState();
+      const saveData = serializeGameState(state)!;
+      const restored = deserializeGameState(saveData);
+
+      expect(restored.screen).toBe("overworld");
+      expect(restored.player!.name).toBe("サトシ");
+      expect(restored.player!.money).toBe(5000);
+      expect(restored.player!.badges).toEqual(["badge1"]);
+    });
+
+    it("string[] がSetに復元される", () => {
+      const state = createTestGameState();
+      const saveData = serializeGameState(state)!;
+      const restored = deserializeGameState(saveData);
+
+      expect(restored.player!.pokedexSeen).toBeInstanceOf(Set);
+      expect(restored.player!.pokedexSeen.has("fire-starter")).toBe(true);
+      expect(restored.player!.pokedexSeen.has("water-starter")).toBe(true);
+      expect(restored.player!.pokedexCaught).toBeInstanceOf(Set);
+      expect(restored.player!.pokedexCaught.has("fire-starter")).toBe(true);
+    });
+
+    it("モンスターデータが正しく復元される", () => {
+      const state = createTestGameState();
+      const saveData = serializeGameState(state)!;
+      const restored = deserializeGameState(saveData);
+      const monster = restored.player!.partyState.party[0];
+
+      expect(monster.uid).toBe("test-uid-001");
+      expect(monster.nature).toBe("adamant");
+      expect(monster.level).toBe(15);
+      expect(monster.status).toBeNull();
+    });
+
+    it("overworldデータが復元される", () => {
+      const state = createTestGameState();
+      const saveData = serializeGameState(state)!;
+      const restored = deserializeGameState(saveData);
+
+      expect(restored.overworld!.currentMapId).toBe("route-1");
+      expect(restored.overworld!.playerX).toBe(5);
+      expect(restored.overworld!.playerY).toBe(10);
+    });
+
+    it("storyFlagsが復元される", () => {
+      const state = createTestGameState();
+      const saveData = serializeGameState(state)!;
+      const restored = deserializeGameState(saveData);
+
+      expect(restored.storyFlags.intro_done).toBe(true);
+    });
+  });
+
+  describe("ラウンドトリップ", () => {
+    it("serialize → deserialize で元のデータと一致する", () => {
+      const original = createTestGameState();
+      const saveData = serializeGameState(original)!;
+      const restored = deserializeGameState(saveData);
+
+      expect(restored.player!.name).toBe(original.player!.name);
+      expect(restored.player!.money).toBe(original.player!.money);
+      expect(restored.player!.partyState.party).toHaveLength(1);
+      expect(restored.player!.partyState.party[0].speciesId).toBe("fire-starter");
+      expect(restored.player!.bag.items).toHaveLength(1);
+      expect(restored.player!.bag.items[0].quantity).toBe(3);
+    });
+
+    it("元のオブジェクトを変更しても復元データに影響しない（ディープコピー）", () => {
+      const original = createTestGameState();
+      const saveData = serializeGameState(original)!;
+
+      // 元データを書き換え
+      original.player!.money = 99999;
+      original.player!.partyState.party[0].level = 100;
+
+      const restored = deserializeGameState(saveData);
+      expect(restored.player!.money).toBe(5000);
+      expect(restored.player!.partyState.party[0].level).toBe(15);
+    });
+  });
+
+  describe("validateSaveData", () => {
+    it("正しいSaveDataを検証通過する", () => {
+      const state = createTestGameState();
+      const saveData = serializeGameState(state)!;
+      expect(validateSaveData(saveData)).toBe(true);
+    });
+
+    it("nullは拒否する", () => {
+      expect(validateSaveData(null)).toBe(false);
+    });
+
+    it("バージョン不一致は拒否する", () => {
+      const state = createTestGameState();
+      const saveData = serializeGameState(state)!;
+      (saveData as unknown as Record<string, unknown>).version = 999;
+      expect(validateSaveData(saveData)).toBe(false);
+    });
+
+    it("playerが欠けていると拒否する", () => {
+      expect(validateSaveData({ version: 1, savedAt: "x", state: {} })).toBe(false);
+    });
+  });
+});
+
+describe("localStorage アダプタ", () => {
+  describe("saveToSlot / loadFromSlot", () => {
+    it("スロットにセーブしてロードできる", () => {
+      const state = createTestGameState();
+      const saveData = serializeGameState(state)!;
+
+      expect(saveToSlot(0, saveData)).toBe(true);
+
+      const loaded = loadFromSlot(0);
+      expect(loaded).not.toBeNull();
+      expect(loaded!.state.player.name).toBe("サトシ");
+    });
+
+    it("空スロットからロードするとnull", () => {
+      expect(loadFromSlot(0)).toBeNull();
+    });
+
+    it("無効なスロット番号は拒否する", () => {
+      const state = createTestGameState();
+      const saveData = serializeGameState(state)!;
+
+      expect(saveToSlot(-1, saveData)).toBe(false);
+      expect(saveToSlot(MAX_SAVE_SLOTS, saveData)).toBe(false);
+      expect(loadFromSlot(-1)).toBeNull();
+      expect(loadFromSlot(MAX_SAVE_SLOTS)).toBeNull();
+    });
+  });
+
+  describe("deleteSlot", () => {
+    it("スロットを削除できる", () => {
+      const state = createTestGameState();
+      const saveData = serializeGameState(state)!;
+      saveToSlot(0, saveData);
+
+      expect(deleteSlot(0)).toBe(true);
+      expect(loadFromSlot(0)).toBeNull();
+    });
+
+    it("無効なスロット番号は拒否する", () => {
+      expect(deleteSlot(-1)).toBe(false);
+    });
+  });
+
+  describe("listSaveSlots", () => {
+    it("全スロットのサマリを返す", () => {
+      const state = createTestGameState();
+      const saveData = serializeGameState(state)!;
+      saveToSlot(0, saveData);
+
+      const slots = listSaveSlots();
+      expect(slots).toHaveLength(MAX_SAVE_SLOTS);
+      expect(slots[0].exists).toBe(true);
+      expect(slots[0].playerName).toBe("サトシ");
+      expect(slots[0].partyLevel).toBe(15);
+      expect(slots[0].badges).toBe(1);
+      expect(slots[1].exists).toBe(false);
+      expect(slots[2].exists).toBe(false);
+    });
+  });
+});
+
+describe("高レベルAPI", () => {
+  it("saveGame → loadGame のラウンドトリップ", () => {
+    const state = createTestGameState();
+
+    expect(saveGame(state, 0, 7200)).toBe(true);
+
+    const restored = loadGame(0);
+    expect(restored).not.toBeNull();
+    expect(restored!.player!.name).toBe("サトシ");
+    expect(restored!.player!.partyState.party[0].uid).toBe("test-uid-001");
+    expect(restored!.player!.pokedexSeen).toBeInstanceOf(Set);
+  });
+
+  it("playerがnullの場合saveGameはfalseを返す", () => {
+    const state: GameState = {
+      screen: "title",
+      player: null,
+      overworld: null,
+      storyFlags: {},
+    };
+    expect(saveGame(state, 0)).toBe(false);
+  });
+
+  it("空スロットのloadGameはnullを返す", () => {
+    expect(loadGame(1)).toBeNull();
+  });
+});

--- a/src/engine/state/game-state.ts
+++ b/src/engine/state/game-state.ts
@@ -74,7 +74,8 @@ export type GameAction =
   | { type: "CHANGE_SCREEN"; screen: ScreenId }
   | { type: "SET_STARTER"; monster: MonsterInstance }
   | { type: "UPDATE_PLAYER"; updates: Partial<PlayerState> }
-  | { type: "SET_STORY_FLAG"; flag: string; value: boolean };
+  | { type: "SET_STORY_FLAG"; flag: string; value: boolean }
+  | { type: "LOAD_GAME"; state: GameState };
 
 /** ゲーム状態のReducer */
 export function gameReducer(state: GameState, action: GameAction): GameState {
@@ -113,6 +114,8 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
         ...state,
         storyFlags: { ...state.storyFlags, [action.flag]: action.value },
       };
+    case "LOAD_GAME":
+      return action.state;
     default:
       return state;
   }

--- a/src/engine/state/save-data.ts
+++ b/src/engine/state/save-data.ts
@@ -1,0 +1,242 @@
+import type { GameState, PlayerState, OverworldState } from "./game-state";
+import type { MonsterInstance, PartyState, Bag, BagItem } from "@/types";
+
+/** セーブデータのバージョン（互換性管理用） */
+export const SAVE_DATA_VERSION = 1;
+
+/** セーブスロット数 */
+export const MAX_SAVE_SLOTS = 3;
+
+/** セーブスロットのキープレフィックス */
+const STORAGE_KEY_PREFIX = "pokemon_save_";
+
+/**
+ * JSON シリアライズ可能なセーブデータ構造
+ * Set → string[] に変換し、保存不要なフィールドを除外
+ */
+export interface SaveData {
+  version: number;
+  savedAt: string;
+  playTime: number;
+  state: SerializedGameState;
+}
+
+/** JSON化可能なGameState */
+export interface SerializedGameState {
+  player: SerializedPlayerState;
+  overworld: OverworldState | null;
+  storyFlags: Record<string, boolean>;
+}
+
+/** JSON化可能なPlayerState (Set → string[]) */
+export interface SerializedPlayerState {
+  name: string;
+  money: number;
+  badges: string[];
+  partyState: PartyState;
+  bag: Bag;
+  pokedexSeen: string[];
+  pokedexCaught: string[];
+}
+
+/** セーブスロットのサマリ（一覧表示用） */
+export interface SaveSlotSummary {
+  slot: number;
+  exists: boolean;
+  playerName?: string;
+  playTime?: number;
+  savedAt?: string;
+  partyLevel?: number;
+  badges?: number;
+}
+
+/**
+ * GameState → SaveData にシリアライズ
+ */
+export function serializeGameState(state: GameState, playTime: number = 0): SaveData | null {
+  if (!state.player) return null;
+
+  return {
+    version: SAVE_DATA_VERSION,
+    savedAt: new Date().toISOString(),
+    playTime,
+    state: {
+      player: serializePlayerState(state.player),
+      overworld: state.overworld,
+      storyFlags: { ...state.storyFlags },
+    },
+  };
+}
+
+function serializePlayerState(player: PlayerState): SerializedPlayerState {
+  return {
+    name: player.name,
+    money: player.money,
+    badges: [...player.badges],
+    partyState: {
+      party: player.partyState.party.map(cloneMonster),
+      boxes: player.partyState.boxes.map((box) => box.map(cloneMonster)),
+    },
+    bag: { items: player.bag.items.map((item) => ({ ...item })) },
+    pokedexSeen: [...player.pokedexSeen],
+    pokedexCaught: [...player.pokedexCaught],
+  };
+}
+
+function cloneMonster(m: MonsterInstance): MonsterInstance {
+  return {
+    uid: m.uid,
+    speciesId: m.speciesId,
+    nickname: m.nickname,
+    level: m.level,
+    exp: m.exp,
+    nature: m.nature,
+    ivs: { ...m.ivs },
+    evs: { ...m.evs },
+    currentHp: m.currentHp,
+    moves: m.moves.map((mv) => ({ ...mv })),
+    status: m.status,
+  };
+}
+
+/**
+ * SaveData → GameState にデシリアライズ
+ */
+export function deserializeGameState(saveData: SaveData): GameState {
+  const { player, overworld, storyFlags } = saveData.state;
+
+  return {
+    screen: "overworld",
+    player: {
+      name: player.name,
+      money: player.money,
+      badges: [...player.badges],
+      partyState: {
+        party: player.partyState.party.map(cloneMonster),
+        boxes: player.partyState.boxes.map((box) => box.map(cloneMonster)),
+      },
+      bag: { items: player.bag.items.map((item: BagItem) => ({ ...item })) },
+      pokedexSeen: new Set(player.pokedexSeen),
+      pokedexCaught: new Set(player.pokedexCaught),
+    },
+    overworld: overworld ? { ...overworld } : null,
+    storyFlags: { ...storyFlags },
+  };
+}
+
+/**
+ * セーブデータのバリデーション
+ */
+export function validateSaveData(data: unknown): data is SaveData {
+  if (typeof data !== "object" || data === null) return false;
+  const d = data as Record<string, unknown>;
+  if (d.version !== SAVE_DATA_VERSION) return false;
+  if (typeof d.savedAt !== "string") return false;
+  if (typeof d.state !== "object" || d.state === null) return false;
+
+  const state = d.state as Record<string, unknown>;
+  if (typeof state.player !== "object" || state.player === null) return false;
+
+  const player = state.player as Record<string, unknown>;
+  if (typeof player.name !== "string") return false;
+  if (!Array.isArray(player.partyState)) {
+    if (typeof player.partyState !== "object" || player.partyState === null) return false;
+  }
+
+  return true;
+}
+
+// --- localStorage アダプタ ---
+
+function getStorageKey(slot: number): string {
+  return `${STORAGE_KEY_PREFIX}${slot}`;
+}
+
+/**
+ * セーブデータを localStorage に保存
+ * @returns 成功したら true
+ */
+export function saveToSlot(slot: number, saveData: SaveData): boolean {
+  if (slot < 0 || slot >= MAX_SAVE_SLOTS) return false;
+  try {
+    const json = JSON.stringify(saveData);
+    localStorage.setItem(getStorageKey(slot), json);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * セーブデータを localStorage から読み込み
+ * @returns SaveData またはバリデーション失敗で null
+ */
+export function loadFromSlot(slot: number): SaveData | null {
+  if (slot < 0 || slot >= MAX_SAVE_SLOTS) return null;
+  try {
+    const json = localStorage.getItem(getStorageKey(slot));
+    if (!json) return null;
+    const data = JSON.parse(json);
+    if (!validateSaveData(data)) return null;
+    return data as SaveData;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * セーブスロットを削除
+ */
+export function deleteSlot(slot: number): boolean {
+  if (slot < 0 || slot >= MAX_SAVE_SLOTS) return false;
+  try {
+    localStorage.removeItem(getStorageKey(slot));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * 全スロットのサマリ一覧を取得
+ */
+export function listSaveSlots(): SaveSlotSummary[] {
+  const summaries: SaveSlotSummary[] = [];
+  for (let i = 0; i < MAX_SAVE_SLOTS; i++) {
+    const data = loadFromSlot(i);
+    if (!data) {
+      summaries.push({ slot: i, exists: false });
+    } else {
+      const party = data.state.player.partyState.party;
+      const maxLevel = party.length > 0 ? Math.max(...party.map((m) => m.level)) : 0;
+      summaries.push({
+        slot: i,
+        exists: true,
+        playerName: data.state.player.name,
+        playTime: data.playTime,
+        savedAt: data.savedAt,
+        partyLevel: maxLevel,
+        badges: data.state.player.badges.length,
+      });
+    }
+  }
+  return summaries;
+}
+
+/**
+ * ゲーム状態をセーブ（高レベルAPI）
+ */
+export function saveGame(state: GameState, slot: number, playTime: number = 0): boolean {
+  const saveData = serializeGameState(state, playTime);
+  if (!saveData) return false;
+  return saveToSlot(slot, saveData);
+}
+
+/**
+ * ゲーム状態をロード（高レベルAPI）
+ */
+export function loadGame(slot: number): GameState | null {
+  const saveData = loadFromSlot(slot);
+  if (!saveData) return null;
+  return deserializeGameState(saveData);
+}


### PR DESCRIPTION
## Summary
- `SaveData` 構造体の設計: バージョン管理、`Set` → `string[]` 変換、プレイ時間記録
- `GameState` ↔ `JSON` のシリアライズ/デシリアライズ（ディープコピーでイミュータブル）
- localStorage アダプタ: 3スロット対応、バリデーション付きロード
- セーブスロットサマリ一覧（プレイヤー名、最高レベル、バッジ数）
- 高レベルAPI `saveGame()` / `loadGame()` を提供
- `LOAD_GAME` アクションを `gameReducer` に追加

## Test plan
- [x] `bun run type-check` — 型エラーなし
- [x] `bun run lint` — エラーなし
- [x] `bun run test` — 187テスト全パス（24テスト新規追加）
- [x] `bun run build` — ビルド成功

Closes #64
Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)