### PR TITLE
feat: オートセーブ機能 + バトル進化チェック + Resolver共通化

### DIFF
--- a/src/engine/map/encounter.ts
+++ b/src/engine/map/encounter.ts
@@ -1,4 +1,4 @@
-import type { MonsterInstance, MonsterSpecies, MoveDefinition } from "@/types";
+import type { MonsterInstance, SpeciesResolver, MoveResolver } from "@/types";
 import type { MapDefinition, EncounterEntry } from "./map-data";
 import { calcAllStats } from "@/engine/monster/stats";
 import { randomNature } from "@/engine/monster/nature";
@@ -59,10 +59,6 @@ export function rollLevel(
 ): number {
   return minLevel + Math.floor(random() * (maxLevel - minLevel + 1));
 }
-
-/** 種族データを引けるリゾルバ */
-export type SpeciesResolver = (speciesId: string) => MonsterSpecies;
-export type MoveResolver = (moveId: string) => MoveDefinition;
 
 /**
  * 野生モンスターのインスタンスを生成

--- a/src/engine/state/__tests__/autosave.test.ts
+++ b/src/engine/state/__tests__/autosave.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  performAutosave,
+  createAutosaveManager,
+  AUTOSAVE_SLOT,
+  AUTOSAVE_DEBOUNCE_MS,
+} from "../autosave";
+import { loadFromSlot } from "../save-data";
+import type { GameState } from "../game-state";
+import type { MonsterInstance } from "@/types";
+
+function createTestMonster(): MonsterInstance {
+  return {
+    uid: "test-autosave",
+    speciesId: "fire-starter",
+    level: 10,
+    exp: 1000,
+    nature: "hardy",
+    ivs: { hp: 15, atk: 15, def: 15, spAtk: 15, spDef: 15, speed: 15 },
+    evs: { hp: 0, atk: 0, def: 0, spAtk: 0, spDef: 0, speed: 0 },
+    currentHp: 30,
+    moves: [{ moveId: "tackle", currentPp: 35 }],
+    status: null,
+  };
+}
+
+function createPlayableState(): GameState {
+  return {
+    screen: "overworld",
+    player: {
+      name: "テスト",
+      money: 3000,
+      badges: [],
+      partyState: {
+        party: [createTestMonster()],
+        boxes: Array.from({ length: 8 }, () => []),
+      },
+      bag: { items: [] },
+      pokedexSeen: new Set(["fire-starter"]),
+      pokedexCaught: new Set(["fire-starter"]),
+    },
+    overworld: { currentMapId: "town-1", playerX: 3, playerY: 5, direction: "down" },
+    storyFlags: {},
+  };
+}
+
+const storage = new Map<string, string>();
+beforeEach(() => {
+  storage.clear();
+  vi.useFakeTimers();
+  Object.defineProperty(globalThis, "localStorage", {
+    value: {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => storage.set(key, value),
+      removeItem: (key: string) => storage.delete(key),
+      clear: () => storage.clear(),
+    },
+    writable: true,
+  });
+});
+
+describe("performAutosave", () => {
+  it("オーバーワールドでオートセーブが成功する", () => {
+    const state = createPlayableState();
+    expect(performAutosave(state, 100)).toBe(true);
+
+    const saved = loadFromSlot(AUTOSAVE_SLOT);
+    expect(saved).not.toBeNull();
+    expect(saved!.state.player.name).toBe("テスト");
+    expect(saved!.playTime).toBe(100);
+  });
+
+  it("playerがnullの場合はセーブしない", () => {
+    const state: GameState = { screen: "title", player: null, overworld: null, storyFlags: {} };
+    expect(performAutosave(state)).toBe(false);
+  });
+
+  it("タイトル画面ではセーブしない", () => {
+    const state = createPlayableState();
+    state.screen = "title";
+    expect(performAutosave(state)).toBe(false);
+  });
+
+  it("スターター選択画面ではセーブしない", () => {
+    const state = createPlayableState();
+    state.screen = "starter_select";
+    expect(performAutosave(state)).toBe(false);
+  });
+});
+
+describe("createAutosaveManager", () => {
+  it("schedule()はデバウンス後に実行される", () => {
+    const manager = createAutosaveManager();
+    const state = createPlayableState();
+
+    manager.schedule(state);
+    expect(loadFromSlot(AUTOSAVE_SLOT)).toBeNull();
+
+    vi.advanceTimersByTime(AUTOSAVE_DEBOUNCE_MS);
+    expect(loadFromSlot(AUTOSAVE_SLOT)).not.toBeNull();
+
+    manager.destroy();
+  });
+
+  it("schedule()が複数回呼ばれても最後の1回だけ実行される", () => {
+    const manager = createAutosaveManager();
+    const state1 = createPlayableState();
+    state1.player!.money = 1000;
+
+    const state2 = createPlayableState();
+    state2.player!.money = 9999;
+
+    manager.schedule(state1);
+    vi.advanceTimersByTime(AUTOSAVE_DEBOUNCE_MS / 2);
+    manager.schedule(state2);
+    vi.advanceTimersByTime(AUTOSAVE_DEBOUNCE_MS);
+
+    const saved = loadFromSlot(AUTOSAVE_SLOT);
+    expect(saved!.state.player.money).toBe(9999);
+
+    manager.destroy();
+  });
+
+  it("saveNow()は即座にセーブする", () => {
+    const manager = createAutosaveManager();
+    const state = createPlayableState();
+
+    expect(manager.saveNow(state)).toBe(true);
+    expect(loadFromSlot(AUTOSAVE_SLOT)).not.toBeNull();
+
+    manager.destroy();
+  });
+
+  it("プレイ時間がカウントされる", () => {
+    const manager = createAutosaveManager();
+
+    manager.startTimer();
+    vi.advanceTimersByTime(5000);
+    expect(manager.getPlayTime()).toBe(5);
+
+    manager.stopTimer();
+    vi.advanceTimersByTime(5000);
+    expect(manager.getPlayTime()).toBe(5);
+
+    manager.destroy();
+  });
+
+  it("setPlayTime()でプレイ時間を復元できる", () => {
+    const manager = createAutosaveManager();
+    manager.setPlayTime(3600);
+    expect(manager.getPlayTime()).toBe(3600);
+    manager.destroy();
+  });
+
+  it("destroy()でタイマーがクリアされる", () => {
+    const manager = createAutosaveManager();
+    const state = createPlayableState();
+
+    manager.startTimer();
+    manager.schedule(state);
+    manager.destroy();
+
+    vi.advanceTimersByTime(AUTOSAVE_DEBOUNCE_MS * 2);
+    expect(loadFromSlot(AUTOSAVE_SLOT)).toBeNull();
+  });
+});

--- a/src/engine/state/autosave.ts
+++ b/src/engine/state/autosave.ts
@@ -1,0 +1,93 @@
+import type { GameState } from "./game-state";
+import { saveGame } from "./save-data";
+
+/** オートセーブ用の専用スロット（スロット0を使用） */
+export const AUTOSAVE_SLOT = 0;
+
+/** オートセーブのデバウンス間隔（ミリ秒） */
+export const AUTOSAVE_DEBOUNCE_MS = 5000;
+
+/** オートセーブ対象のアクション種別 */
+export type AutosaveTrigger =
+  | "battle_end"
+  | "map_transition"
+  | "healing"
+  | "starter_selected"
+  | "item_obtained";
+
+/**
+ * オートセーブを実行
+ * @returns 成功したら true
+ */
+export function performAutosave(state: GameState, playTime: number = 0): boolean {
+  if (!state.player) return false;
+  if (state.screen === "title" || state.screen === "starter_select") return false;
+  return saveGame(state, AUTOSAVE_SLOT, playTime);
+}
+
+/**
+ * デバウンス付きオートセーブマネージャ
+ * 短時間に複数回呼ばれても最後の1回だけ実行する
+ */
+export function createAutosaveManager() {
+  let timerId: ReturnType<typeof setTimeout> | null = null;
+  let playTimeSeconds = 0;
+  let playTimeInterval: ReturnType<typeof setInterval> | null = null;
+
+  return {
+    /** プレイ時間の計測を開始 */
+    startTimer() {
+      if (playTimeInterval) return;
+      playTimeInterval = setInterval(() => {
+        playTimeSeconds++;
+      }, 1000);
+    },
+
+    /** プレイ時間の計測を停止 */
+    stopTimer() {
+      if (playTimeInterval) {
+        clearInterval(playTimeInterval);
+        playTimeInterval = null;
+      }
+    },
+
+    /** 現在のプレイ時間（秒）を取得 */
+    getPlayTime(): number {
+      return playTimeSeconds;
+    },
+
+    /** プレイ時間を復元（ロード時に使用） */
+    setPlayTime(seconds: number) {
+      playTimeSeconds = seconds;
+    },
+
+    /** デバウンス付きオートセーブをスケジュール */
+    schedule(state: GameState): void {
+      if (timerId !== null) {
+        clearTimeout(timerId);
+      }
+      timerId = setTimeout(() => {
+        performAutosave(state, playTimeSeconds);
+        timerId = null;
+      }, AUTOSAVE_DEBOUNCE_MS);
+    },
+
+    /** 即時実行（画面遷移前など） */
+    saveNow(state: GameState): boolean {
+      if (timerId !== null) {
+        clearTimeout(timerId);
+        timerId = null;
+      }
+      return performAutosave(state, playTimeSeconds);
+    },
+
+    /** クリーンアップ */
+    destroy() {
+      if (timerId !== null) {
+        clearTimeout(timerId);
+        timerId = null;
+      }
+      this.stopTimer();
+    },
+  };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -160,3 +160,8 @@ export interface PartyState {
   /** ボックス（預かりシステム） */
   boxes: MonsterInstance[][];
 }
+
+/** 種族データを引けるリゾルバ */
+export type SpeciesResolver = (speciesId: string) => MonsterSpecies;
+/** 技データを引けるリゾルバ */
+export type MoveResolver = (moveId: string) => MoveDefinition;


### PR DESCRIPTION
## Summary
- **#71 オートセーブ機能**: `performAutosave()` と `createAutosaveManager()` を実装。デバウンス付きスケジュール、即時セーブ、プレイ時間計測をサポート。タイトル/スターター選択画面では自動的にスキップ
- **バトル進化チェック**: レベルアップ後に `checkEvolution()` → `evolve()` を実行するよう `engine.ts` を修正
- **Resolver共通化**: `SpeciesResolver` / `MoveResolver` 型を `types/index.ts` に集約し、`engine.ts` / `encounter.ts` の重複定義を削除

## Test plan
- [x] 全197テスト通過（新規10テスト含む）
- [x] `bun run type-check` クリーン
- [x] `bun run lint` エラー/警告なし
- [x] `bun run build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)