### PR TITLE
feat: ストーリーフラグ管理システム (#39)

### DIFF
--- a/src/engine/map/__tests__/npc.test.ts
+++ b/src/engine/map/__tests__/npc.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { interactWithNpc } from "../npc";
+import { interactWithNpc, resolveNpcDialogue, isNpcVisible, getVisibleNpcs } from "../npc";
 import type { NpcDefinition } from "../map-data";
 
 const npcs: NpcDefinition[] = [
@@ -38,5 +38,165 @@ describe("NPC会話システム", () => {
   it("存在しないNPCにはnullが返る", () => {
     const result = interactWithNpc("unknown", npcs);
     expect(result).toBeNull();
+  });
+});
+
+describe("条件付きダイアログ", () => {
+  const npcWithConditional: NpcDefinition = {
+    id: "elder",
+    name: "長老",
+    x: 3,
+    y: 3,
+    dialogue: ["ここは始まりの町じゃ。"],
+    conditionalDialogues: [
+      {
+        condition: "gym1_cleared",
+        dialogue: ["ジムバッジを手に入れたのか！大したものじゃ。"],
+      },
+      {
+        condition: "intro_done",
+        dialogue: ["冒険の準備はできたかの？"],
+      },
+    ],
+    isTrainer: false,
+  };
+
+  it("条件を満たさない場合はデフォルトダイアログ", () => {
+    const dialogue = resolveNpcDialogue(npcWithConditional, {});
+    expect(dialogue).toEqual(["ここは始まりの町じゃ。"]);
+  });
+
+  it("最初に条件を満たしたダイアログが使用される", () => {
+    const flags = { gym1_cleared: true, intro_done: true };
+    const dialogue = resolveNpcDialogue(npcWithConditional, flags);
+    expect(dialogue).toEqual(["ジムバッジを手に入れたのか！大したものじゃ。"]);
+  });
+
+  it("2番目の条件のみ満たす場合はそのダイアログ", () => {
+    const flags = { intro_done: true };
+    const dialogue = resolveNpcDialogue(npcWithConditional, flags);
+    expect(dialogue).toEqual(["冒険の準備はできたかの？"]);
+  });
+
+  it("AND条件の条件付きダイアログ", () => {
+    const npc: NpcDefinition = {
+      id: "guard",
+      name: "門番",
+      x: 1,
+      y: 1,
+      dialogue: ["ここから先は通せない。"],
+      conditionalDialogues: [
+        {
+          condition: ["gym1_cleared", "gym2_cleared"],
+          dialogue: ["バッジを2つ持っているな。通ってよし。"],
+        },
+      ],
+      isTrainer: false,
+    };
+
+    expect(resolveNpcDialogue(npc, { gym1_cleared: true })).toEqual(["ここから先は通せない。"]);
+    expect(resolveNpcDialogue(npc, { gym1_cleared: true, gym2_cleared: true })).toEqual([
+      "バッジを2つ持っているな。通ってよし。",
+    ]);
+  });
+
+  it("interactWithNpcでも条件分岐が反映される", () => {
+    const result = interactWithNpc("elder", [npcWithConditional], new Set(), { intro_done: true });
+    expect(result).not.toBeNull();
+    expect(result!.dialogue).toEqual(["冒険の準備はできたかの？"]);
+  });
+});
+
+describe("NPCイベントトリガー", () => {
+  it("onInteractイベントが返される", () => {
+    const npc: NpcDefinition = {
+      id: "professor",
+      name: "博士",
+      x: 5,
+      y: 5,
+      dialogue: ["ようこそ！モンスターの世界へ！"],
+      isTrainer: false,
+      onInteract: {
+        setFlags: { intro_done: true },
+      },
+    };
+
+    const result = interactWithNpc("professor", [npc]);
+    expect(result).not.toBeNull();
+    expect(result!.event).toEqual({ setFlags: { intro_done: true } });
+  });
+
+  it("onInteractがない場合はeventがnull", () => {
+    const result = interactWithNpc("villager", npcs);
+    expect(result!.event).toBeNull();
+  });
+});
+
+describe("NPC出現条件", () => {
+  const conditionalNpcs: NpcDefinition[] = [
+    {
+      id: "always-visible",
+      name: "常駐NPC",
+      x: 1,
+      y: 1,
+      dialogue: ["こんにちは"],
+      isTrainer: false,
+    },
+    {
+      id: "post-gym",
+      name: "ジム後NPC",
+      x: 2,
+      y: 2,
+      dialogue: ["おめでとう！"],
+      isTrainer: false,
+      appearCondition: "gym1_cleared",
+    },
+    {
+      id: "pre-event",
+      name: "イベント前NPC",
+      x: 3,
+      y: 3,
+      dialogue: ["何か起きそうだ…"],
+      isTrainer: false,
+      appearCondition: { flag: "event_started", value: false },
+    },
+  ];
+
+  it("appearConditionがないNPCは常に表示", () => {
+    expect(isNpcVisible(conditionalNpcs[0], {})).toBe(true);
+  });
+
+  it("appearConditionを満たすNPCは表示", () => {
+    expect(isNpcVisible(conditionalNpcs[1], { gym1_cleared: true })).toBe(true);
+  });
+
+  it("appearConditionを満たさないNPCは非表示", () => {
+    expect(isNpcVisible(conditionalNpcs[1], {})).toBe(false);
+  });
+
+  it("value=false条件のNPC出現チェック", () => {
+    expect(isNpcVisible(conditionalNpcs[2], {})).toBe(true);
+    expect(isNpcVisible(conditionalNpcs[2], { event_started: true })).toBe(false);
+  });
+
+  it("getVisibleNpcsがフィルタリングされたリストを返す", () => {
+    const visible = getVisibleNpcs(conditionalNpcs, {});
+    expect(visible.map((n) => n.id)).toEqual(["always-visible", "pre-event"]);
+  });
+
+  it("getVisibleNpcsにフラグを渡すと結果が変わる", () => {
+    const visible = getVisibleNpcs(conditionalNpcs, { gym1_cleared: true, event_started: true });
+    expect(visible.map((n) => n.id)).toEqual(["always-visible", "post-gym"]);
+  });
+
+  it("出現条件を満たさないNPCにはinteractWithNpcがnullを返す", () => {
+    const result = interactWithNpc("post-gym", conditionalNpcs, new Set(), {});
+    expect(result).toBeNull();
+  });
+
+  it("出現条件を満たすNPCには通常通りインタラクトできる", () => {
+    const result = interactWithNpc("post-gym", conditionalNpcs, new Set(), { gym1_cleared: true });
+    expect(result).not.toBeNull();
+    expect(result!.dialogue).toEqual(["おめでとう！"]);
   });
 });

--- a/src/engine/map/map-data.ts
+++ b/src/engine/map/map-data.ts
@@ -1,4 +1,5 @@
 import type { MapId, MonsterId } from "@/types";
+import type { FlagRequirement } from "@/engine/state/story-flags";
 
 /** タイルの種類 */
 export type TileType = "ground" | "wall" | "grass" | "water" | "ledge" | "door" | "sign";
@@ -34,16 +35,40 @@ export interface EncounterEntry {
   weight: number;
 }
 
+/** 条件付きダイアログ — ストーリーフラグに基づいて分岐 */
+export interface ConditionalDialogue {
+  /** この条件を満たす場合にこのダイアログを使用 */
+  condition: FlagRequirement;
+  /** 条件を満たした場合のダイアログテキスト */
+  dialogue: string[];
+}
+
+/** NPC会話完了時に発火するイベント */
+export interface NpcEvent {
+  /** 設定するフラグ */
+  setFlags?: Record<string, boolean>;
+  /** 回復イベント */
+  heal?: boolean;
+  /** アイテム付与 */
+  giveItem?: { itemId: string; quantity: number };
+}
+
 /** NPC定義 */
 export interface NpcDefinition {
   id: string;
   name: string;
   x: number;
   y: number;
-  /** 会話テキスト（配列で複数ページ） */
+  /** デフォルト会話テキスト（配列で複数ページ） */
   dialogue: string[];
+  /** 条件付きダイアログ（上から順に評価、最初に条件を満たしたものを使用） */
+  conditionalDialogues?: ConditionalDialogue[];
   /** トレーナーとして戦闘するか */
   isTrainer: boolean;
+  /** 会話完了時に実行するイベント */
+  onInteract?: NpcEvent;
+  /** このNPCが出現するための条件（未設定なら常に出現） */
+  appearCondition?: FlagRequirement;
 }
 
 /** マップ定義 */

--- a/src/engine/map/npc.ts
+++ b/src/engine/map/npc.ts
@@ -1,15 +1,53 @@
-import type { NpcDefinition } from "./map-data";
+import type { NpcDefinition, NpcEvent } from "./map-data";
+import type { StoryFlags } from "@/engine/state/story-flags";
+import { checkFlagRequirement } from "@/engine/state/story-flags";
 
 /**
- * NPC配置と会話システム (#41)
+ * NPC配置と会話システム (#41, #39)
  */
 
 export interface NpcInteractionResult {
   npc: NpcDefinition;
-  /** 会話テキスト */
+  /** 会話テキスト（条件分岐後） */
   dialogue: string[];
   /** トレーナー戦が発生するか */
   triggerBattle: boolean;
+  /** 会話完了時に実行するイベント */
+  event: NpcEvent | null;
+}
+
+/**
+ * NPCのダイアログを解決する（条件分岐対応）
+ * conditionalDialoguesを上から順に評価し、最初に条件を満たしたものを返す。
+ * いずれも満たさない場合はデフォルトのdialogueを返す。
+ */
+export function resolveNpcDialogue(
+  npc: NpcDefinition,
+  storyFlags: StoryFlags = {},
+): string[] {
+  if (npc.conditionalDialogues) {
+    for (const cd of npc.conditionalDialogues) {
+      if (checkFlagRequirement(storyFlags, cd.condition)) {
+        return cd.dialogue;
+      }
+    }
+  }
+  return npc.dialogue;
+}
+
+/**
+ * マップ上でストーリーフラグに基づきNPCが出現しているか判定
+ */
+export function isNpcVisible(npc: NpcDefinition, storyFlags: StoryFlags = {}): boolean {
+  if (!npc.appearCondition) return true;
+  return checkFlagRequirement(storyFlags, npc.appearCondition);
+}
+
+/**
+ * マップ上の可視NPCリストを取得
+ */
+export function getVisibleNpcs(npcs: NpcDefinition[], storyFlags: StoryFlags = {}): NpcDefinition[] {
+  return npcs.filter((npc) => isNpcVisible(npc, storyFlags));
 }
 
 /**
@@ -17,20 +55,26 @@ export interface NpcInteractionResult {
  * @param npcId NPC ID
  * @param npcs マップ上のNPC一覧
  * @param defeatedTrainers 倒済みトレーナーIDのSet
+ * @param storyFlags 現在のストーリーフラグ
  */
 export function interactWithNpc(
   npcId: string,
   npcs: NpcDefinition[],
   defeatedTrainers: Set<string> = new Set(),
+  storyFlags: StoryFlags = {},
 ): NpcInteractionResult | null {
   const npc = npcs.find((n) => n.id === npcId);
   if (!npc) return null;
+
+  // 出現条件チェック
+  if (!isNpcVisible(npc, storyFlags)) return null;
 
   const alreadyDefeated = defeatedTrainers.has(npc.id);
 
   return {
     npc,
-    dialogue: npc.dialogue,
+    dialogue: resolveNpcDialogue(npc, storyFlags),
     triggerBattle: npc.isTrainer && !alreadyDefeated,
+    event: npc.onInteract ?? null,
   };
 }

--- a/src/engine/state/__tests__/story-flags.test.ts
+++ b/src/engine/state/__tests__/story-flags.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import {
+  checkFlagRequirement,
+  setFlags,
+  hasFlag,
+  hasAllFlags,
+  hasAnyFlag,
+} from "../story-flags";
+import type { StoryFlags } from "../story-flags";
+
+describe("story-flags", () => {
+  describe("hasFlag", () => {
+    it("trueのフラグを検出する", () => {
+      const flags: StoryFlags = { intro_done: true };
+      expect(hasFlag(flags, "intro_done")).toBe(true);
+    });
+
+    it("未設定のフラグはfalse", () => {
+      const flags: StoryFlags = {};
+      expect(hasFlag(flags, "intro_done")).toBe(false);
+    });
+
+    it("falseのフラグはfalse", () => {
+      const flags: StoryFlags = { intro_done: false };
+      expect(hasFlag(flags, "intro_done")).toBe(false);
+    });
+  });
+
+  describe("hasAllFlags", () => {
+    it("すべてのフラグがtrueの場合true", () => {
+      const flags: StoryFlags = { gym1_cleared: true, gym2_cleared: true };
+      expect(hasAllFlags(flags, ["gym1_cleared", "gym2_cleared"])).toBe(true);
+    });
+
+    it("一つでもfalseならfalse", () => {
+      const flags: StoryFlags = { gym1_cleared: true, gym2_cleared: false };
+      expect(hasAllFlags(flags, ["gym1_cleared", "gym2_cleared"])).toBe(false);
+    });
+
+    it("空配列はtrue", () => {
+      expect(hasAllFlags({}, [])).toBe(true);
+    });
+  });
+
+  describe("hasAnyFlag", () => {
+    it("いずれかのフラグがtrueならtrue", () => {
+      const flags: StoryFlags = { gym1_cleared: false, gym2_cleared: true };
+      expect(hasAnyFlag(flags, ["gym1_cleared", "gym2_cleared"])).toBe(true);
+    });
+
+    it("すべてfalseならfalse", () => {
+      const flags: StoryFlags = { gym1_cleared: false };
+      expect(hasAnyFlag(flags, ["gym1_cleared", "gym2_cleared"])).toBe(false);
+    });
+
+    it("空配列はfalse", () => {
+      expect(hasAnyFlag({}, [])).toBe(false);
+    });
+  });
+
+  describe("checkFlagRequirement", () => {
+    it("文字列条件: フラグがtrueなら満たす", () => {
+      const flags: StoryFlags = { intro_done: true };
+      expect(checkFlagRequirement(flags, "intro_done")).toBe(true);
+    });
+
+    it("文字列条件: フラグがfalse/未設定なら満たさない", () => {
+      expect(checkFlagRequirement({}, "intro_done")).toBe(false);
+      expect(checkFlagRequirement({ intro_done: false }, "intro_done")).toBe(false);
+    });
+
+    it("オブジェクト条件: value=trueの判定", () => {
+      const flags: StoryFlags = { gym1_cleared: true };
+      expect(checkFlagRequirement(flags, { flag: "gym1_cleared", value: true })).toBe(true);
+    });
+
+    it("オブジェクト条件: value=falseの判定（フラグが未設定の場合もfalseとして扱う）", () => {
+      expect(checkFlagRequirement({}, { flag: "gym1_cleared", value: false })).toBe(true);
+      expect(checkFlagRequirement({ gym1_cleared: false }, { flag: "gym1_cleared", value: false })).toBe(true);
+      expect(checkFlagRequirement({ gym1_cleared: true }, { flag: "gym1_cleared", value: false })).toBe(false);
+    });
+
+    it("配列条件（AND）: すべて満たす場合true", () => {
+      const flags: StoryFlags = { intro_done: true, gym1_cleared: true };
+      expect(checkFlagRequirement(flags, ["intro_done", "gym1_cleared"])).toBe(true);
+    });
+
+    it("配列条件（AND）: 一つでも満たさなければfalse", () => {
+      const flags: StoryFlags = { intro_done: true };
+      expect(checkFlagRequirement(flags, ["intro_done", "gym1_cleared"])).toBe(false);
+    });
+
+    it("配列条件に混在（文字列+オブジェクト）", () => {
+      const flags: StoryFlags = { intro_done: true, evil_team_defeated: false };
+      expect(
+        checkFlagRequirement(flags, [
+          "intro_done",
+          { flag: "evil_team_defeated", value: false },
+        ]),
+      ).toBe(true);
+    });
+  });
+
+  describe("setFlags", () => {
+    it("新しいフラグを追加する", () => {
+      const flags: StoryFlags = { intro_done: true };
+      const result = setFlags(flags, { gym1_cleared: true });
+      expect(result).toEqual({ intro_done: true, gym1_cleared: true });
+    });
+
+    it("既存のフラグを上書きする", () => {
+      const flags: StoryFlags = { intro_done: false };
+      const result = setFlags(flags, { intro_done: true });
+      expect(result).toEqual({ intro_done: true });
+    });
+
+    it("元のオブジェクトを変更しない（イミュータブル）", () => {
+      const flags: StoryFlags = { intro_done: true };
+      const result = setFlags(flags, { gym1_cleared: true });
+      expect(flags).toEqual({ intro_done: true });
+      expect(result).not.toBe(flags);
+    });
+
+    it("複数フラグを一度に設定する", () => {
+      const result = setFlags({}, { intro_done: true, gym1_cleared: true, gym2_cleared: false });
+      expect(result).toEqual({ intro_done: true, gym1_cleared: true, gym2_cleared: false });
+    });
+  });
+});

--- a/src/engine/state/story-flags.ts
+++ b/src/engine/state/story-flags.ts
@@ -1,0 +1,72 @@
+/**
+ * ストーリーフラグ管理システム (#39)
+ * イベント進行状態の条件判定・操作ユーティリティ
+ */
+
+/** ストーリーフラグの型（GameState.storyFlagsと同一） */
+export type StoryFlags = Record<string, boolean>;
+
+/**
+ * フラグ条件: 単一フラグのチェック
+ * - string: そのフラグがtrueであること
+ * - { flag: string; value: boolean }: 指定の値であること
+ */
+export type FlagCondition =
+  | string
+  | { flag: string; value: boolean };
+
+/**
+ * 複合フラグ条件
+ * - 配列はAND条件（すべてを満たす）
+ */
+export type FlagRequirement = FlagCondition | FlagCondition[];
+
+/**
+ * 単一のフラグ条件を評価する
+ */
+function evaluateCondition(flags: StoryFlags, condition: FlagCondition): boolean {
+  if (typeof condition === "string") {
+    return flags[condition] === true;
+  }
+  return (flags[condition.flag] ?? false) === condition.value;
+}
+
+/**
+ * フラグ条件を満たしているか判定
+ * 配列はAND条件（すべてを満たす必要がある）
+ */
+export function checkFlagRequirement(flags: StoryFlags, requirement: FlagRequirement): boolean {
+  if (Array.isArray(requirement)) {
+    return requirement.every((cond) => evaluateCondition(flags, cond));
+  }
+  return evaluateCondition(flags, requirement);
+}
+
+/**
+ * 複数のフラグを一度に設定する
+ * @returns 新しいstoryFlagsオブジェクト（イミュータブル）
+ */
+export function setFlags(flags: StoryFlags, updates: Record<string, boolean>): StoryFlags {
+  return { ...flags, ...updates };
+}
+
+/**
+ * 指定フラグがtrueか確認する（ショートカット）
+ */
+export function hasFlag(flags: StoryFlags, flag: string): boolean {
+  return flags[flag] === true;
+}
+
+/**
+ * 複数フラグがすべてtrueか確認する
+ */
+export function hasAllFlags(flags: StoryFlags, flagNames: string[]): boolean {
+  return flagNames.every((f) => flags[f] === true);
+}
+
+/**
+ * 複数フラグのいずれかがtrueか確認する
+ */
+export function hasAnyFlag(flags: StoryFlags, flagNames: string[]): boolean {
+  return flagNames.some((f) => flags[f] === true);
+}


### PR DESCRIPTION
## Summary
- **ストーリーフラグ条件判定API** (`story-flags.ts`): `hasFlag`, `hasAllFlags`, `hasAnyFlag`, `checkFlagRequirement`, `setFlags` を実装。文字列条件・オブジェクト条件・配列AND条件をサポート
- **NPC条件分岐**: `conditionalDialogues` によるストーリーフラグに基づくダイアログ分岐、`appearCondition` によるNPC出現条件、`onInteract` によるイベントトリガー
- **NPC関数拡張**: `interactWithNpc` にstoryFlags引数追加、`resolveNpcDialogue`, `isNpcVisible`, `getVisibleNpcs` ユーティリティ追加

Closes #39

## Test plan
- [x] 全232テスト通過（新規35テスト含む: story-flags 20件 + npc拡張 15件）
- [x] `bun run type-check` クリーン
- [x] `bun run lint` エラー/警告なし
- [x] `bun run build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)