### PR TITLE
feat: イベントスクリプトエンジン (#42)

### DIFF
--- a/src/engine/event/__tests__/event-script.test.ts
+++ b/src/engine/event/__tests__/event-script.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect } from "vitest";
+import {
+  canTriggerScript,
+  resolveCommands,
+  executeScript,
+} from "../event-script";
+import type { EventScript, EventCommand } from "../event-script";
+
+describe("canTriggerScript", () => {
+  it("triggerがないスクリプトは常に実行可能", () => {
+    const script: EventScript = { id: "test", commands: [] };
+    expect(canTriggerScript(script, {})).toBe(true);
+  });
+
+  it("trigger条件を満たすスクリプトは実行可能", () => {
+    const script: EventScript = { id: "test", trigger: "intro_done", commands: [] };
+    expect(canTriggerScript(script, { intro_done: true })).toBe(true);
+  });
+
+  it("trigger条件を満たさないスクリプトは実行不可", () => {
+    const script: EventScript = { id: "test", trigger: "intro_done", commands: [] };
+    expect(canTriggerScript(script, {})).toBe(false);
+  });
+
+  it("AND条件のtrigger", () => {
+    const script: EventScript = {
+      id: "test",
+      trigger: ["intro_done", "gym1_cleared"],
+      commands: [],
+    };
+    expect(canTriggerScript(script, { intro_done: true })).toBe(false);
+    expect(canTriggerScript(script, { intro_done: true, gym1_cleared: true })).toBe(true);
+  });
+});
+
+describe("resolveCommands", () => {
+  it("dialogueコマンドを解決する", () => {
+    const commands: EventCommand[] = [
+      { type: "dialogue", speaker: "博士", lines: ["ようこそ！", "モンスターの世界へ！"] },
+    ];
+    const outputs = resolveCommands(commands, {});
+    expect(outputs).toEqual([
+      { type: "dialogue", speaker: "博士", lines: ["ようこそ！", "モンスターの世界へ！"] },
+    ]);
+  });
+
+  it("speakerなしのdialogue", () => {
+    const commands: EventCommand[] = [
+      { type: "dialogue", lines: ["ナレーション"] },
+    ];
+    const outputs = resolveCommands(commands, {});
+    expect(outputs[0]).toEqual({
+      type: "dialogue",
+      speaker: undefined,
+      lines: ["ナレーション"],
+    });
+  });
+
+  it("set_flagコマンドを解決する", () => {
+    const commands: EventCommand[] = [
+      { type: "set_flag", flag: "intro_done", value: true },
+    ];
+    const outputs = resolveCommands(commands, {});
+    expect(outputs).toEqual([
+      { type: "set_flag", flag: "intro_done", value: true },
+    ]);
+  });
+
+  it("healコマンドを解決する", () => {
+    const outputs = resolveCommands([{ type: "heal" }], {});
+    expect(outputs).toEqual([{ type: "heal" }]);
+  });
+
+  it("give_itemコマンドを解決する", () => {
+    const commands: EventCommand[] = [
+      { type: "give_item", itemId: "potion", quantity: 5 },
+    ];
+    const outputs = resolveCommands(commands, {});
+    expect(outputs).toEqual([
+      { type: "give_item", itemId: "potion", quantity: 5 },
+    ]);
+  });
+
+  it("battleコマンドを解決する", () => {
+    const commands: EventCommand[] = [
+      {
+        type: "battle",
+        trainerName: "ジムリーダー",
+        party: [{ speciesId: "fire-starter", level: 15 }],
+      },
+    ];
+    const outputs = resolveCommands(commands, {});
+    expect(outputs).toEqual([
+      {
+        type: "battle",
+        trainerName: "ジムリーダー",
+        party: [{ speciesId: "fire-starter", level: 15 }],
+      },
+    ]);
+  });
+
+  it("move_playerコマンドを解決する", () => {
+    const commands: EventCommand[] = [
+      { type: "move_player", mapId: "town-2", x: 5, y: 3 },
+    ];
+    const outputs = resolveCommands(commands, {});
+    expect(outputs).toEqual([
+      { type: "move_player", mapId: "town-2", x: 5, y: 3 },
+    ]);
+  });
+
+  it("waitコマンドを解決する", () => {
+    const outputs = resolveCommands([{ type: "wait", ms: 1000 }], {});
+    expect(outputs).toEqual([{ type: "wait", ms: 1000 }]);
+  });
+
+  it("複数コマンドを順番に解決する", () => {
+    const commands: EventCommand[] = [
+      { type: "dialogue", speaker: "博士", lines: ["まずはこれを受け取りなさい。"] },
+      { type: "give_item", itemId: "potion", quantity: 3 },
+      { type: "set_flag", flag: "received_starter_items", value: true },
+    ];
+    const outputs = resolveCommands(commands, {});
+    expect(outputs).toHaveLength(3);
+    expect(outputs[0].type).toBe("dialogue");
+    expect(outputs[1].type).toBe("give_item");
+    expect(outputs[2].type).toBe("set_flag");
+  });
+});
+
+describe("branch コマンド", () => {
+  it("条件を満たす場合thenを実行", () => {
+    const commands: EventCommand[] = [
+      {
+        type: "branch",
+        condition: "gym1_cleared",
+        then: [{ type: "dialogue", lines: ["ジムバッジを持っているね。"] }],
+        else: [{ type: "dialogue", lines: ["まだジムバッジがないようだ。"] }],
+      },
+    ];
+    const outputs = resolveCommands(commands, { gym1_cleared: true });
+    expect(outputs).toEqual([
+      { type: "dialogue", speaker: undefined, lines: ["ジムバッジを持っているね。"] },
+    ]);
+  });
+
+  it("条件を満たさない場合elseを実行", () => {
+    const commands: EventCommand[] = [
+      {
+        type: "branch",
+        condition: "gym1_cleared",
+        then: [{ type: "dialogue", lines: ["OK"] }],
+        else: [{ type: "dialogue", lines: ["まだだ。"] }],
+      },
+    ];
+    const outputs = resolveCommands(commands, {});
+    expect(outputs).toEqual([
+      { type: "dialogue", speaker: undefined, lines: ["まだだ。"] },
+    ]);
+  });
+
+  it("elseが未定義で条件を満たさない場合、出力なし", () => {
+    const commands: EventCommand[] = [
+      {
+        type: "branch",
+        condition: "gym1_cleared",
+        then: [{ type: "dialogue", lines: ["OK"] }],
+      },
+    ];
+    const outputs = resolveCommands(commands, {});
+    expect(outputs).toEqual([]);
+  });
+
+  it("ネストされた分岐", () => {
+    const commands: EventCommand[] = [
+      {
+        type: "branch",
+        condition: "intro_done",
+        then: [
+          {
+            type: "branch",
+            condition: "gym1_cleared",
+            then: [{ type: "dialogue", lines: ["完全クリア！"] }],
+            else: [{ type: "dialogue", lines: ["ジムに挑戦しよう。"] }],
+          },
+        ],
+        else: [{ type: "dialogue", lines: ["まずは冒険を始めよう。"] }],
+      },
+    ];
+
+    expect(resolveCommands(commands, {})).toEqual([
+      { type: "dialogue", speaker: undefined, lines: ["まずは冒険を始めよう。"] },
+    ]);
+
+    expect(resolveCommands(commands, { intro_done: true })).toEqual([
+      { type: "dialogue", speaker: undefined, lines: ["ジムに挑戦しよう。"] },
+    ]);
+
+    expect(resolveCommands(commands, { intro_done: true, gym1_cleared: true })).toEqual([
+      { type: "dialogue", speaker: undefined, lines: ["完全クリア！"] },
+    ]);
+  });
+
+  it("スクリプト実行中にset_flagで変更されたフラグが後続branchに反映される", () => {
+    const commands: EventCommand[] = [
+      { type: "set_flag", flag: "talked_to_professor", value: true },
+      {
+        type: "branch",
+        condition: "talked_to_professor",
+        then: [{ type: "dialogue", lines: ["フラグが反映された！"] }],
+        else: [{ type: "dialogue", lines: ["反映されなかった…"] }],
+      },
+    ];
+    const outputs = resolveCommands(commands, {});
+    expect(outputs).toEqual([
+      { type: "set_flag", flag: "talked_to_professor", value: true },
+      { type: "dialogue", speaker: undefined, lines: ["フラグが反映された！"] },
+    ]);
+  });
+});
+
+describe("executeScript", () => {
+  it("trigger条件を満たすスクリプトは実行される", () => {
+    const script: EventScript = {
+      id: "intro",
+      trigger: "game_started",
+      commands: [
+        { type: "dialogue", speaker: "博士", lines: ["ようこそ！"] },
+        { type: "set_flag", flag: "intro_done", value: true },
+      ],
+    };
+
+    const result = executeScript(script, { game_started: true });
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(2);
+  });
+
+  it("trigger条件を満たさないスクリプトはnullを返す", () => {
+    const script: EventScript = {
+      id: "intro",
+      trigger: "game_started",
+      commands: [{ type: "dialogue", lines: ["test"] }],
+    };
+    expect(executeScript(script, {})).toBeNull();
+  });
+
+  it("triggerなしのスクリプトは常に実行される", () => {
+    const script: EventScript = {
+      id: "test",
+      commands: [{ type: "dialogue", lines: ["hello"] }],
+    };
+    expect(executeScript(script, {})).not.toBeNull();
+  });
+
+  it("複合イベントスクリプトの統合テスト", () => {
+    const script: EventScript = {
+      id: "professor_event",
+      commands: [
+        { type: "dialogue", speaker: "博士", lines: ["やあ！来てくれたか。"] },
+        {
+          type: "branch",
+          condition: "has_starter",
+          then: [
+            { type: "dialogue", speaker: "博士", lines: ["モンスターの調子はどうだ？"] },
+          ],
+          else: [
+            { type: "dialogue", speaker: "博士", lines: ["君にモンスターをあげよう！"] },
+            { type: "give_item", itemId: "potion", quantity: 5 },
+            { type: "set_flag", flag: "has_starter", value: true },
+          ],
+        },
+        { type: "dialogue", speaker: "博士", lines: ["頑張れよ！"] },
+      ],
+    };
+
+    // 初回実行（スターターなし）
+    const firstRun = executeScript(script, {})!;
+    expect(firstRun).toHaveLength(5);
+    expect(firstRun[0]).toEqual({
+      type: "dialogue",
+      speaker: "博士",
+      lines: ["やあ！来てくれたか。"],
+    });
+    expect(firstRun[1]).toEqual({
+      type: "dialogue",
+      speaker: "博士",
+      lines: ["君にモンスターをあげよう！"],
+    });
+    expect(firstRun[2]).toEqual({ type: "give_item", itemId: "potion", quantity: 5 });
+    expect(firstRun[3]).toEqual({ type: "set_flag", flag: "has_starter", value: true });
+    expect(firstRun[4]).toEqual({
+      type: "dialogue",
+      speaker: "博士",
+      lines: ["頑張れよ！"],
+    });
+
+    // 2回目実行（スターターあり）
+    const secondRun = executeScript(script, { has_starter: true })!;
+    expect(secondRun).toHaveLength(3);
+    expect(secondRun[1]).toEqual({
+      type: "dialogue",
+      speaker: "博士",
+      lines: ["モンスターの調子はどうだ？"],
+    });
+  });
+});

--- a/src/engine/event/event-script.ts
+++ b/src/engine/event/event-script.ts
@@ -1,0 +1,170 @@
+/**
+ * イベントスクリプトエンジン (#42)
+ * 会話、カットシーン、分岐をスクリプトとして記述・実行する
+ */
+
+import type { FlagRequirement, StoryFlags } from "@/engine/state/story-flags";
+import { checkFlagRequirement } from "@/engine/state/story-flags";
+
+// ── コマンド定義 ──
+
+/** 会話を表示 */
+export interface DialogueCommand {
+  type: "dialogue";
+  speaker?: string;
+  lines: string[];
+}
+
+/** ストーリーフラグを設定 */
+export interface SetFlagCommand {
+  type: "set_flag";
+  flag: string;
+  value: boolean;
+}
+
+/** 条件分岐 */
+export interface BranchCommand {
+  type: "branch";
+  condition: FlagRequirement;
+  /** 条件を満たした場合に実行するコマンド列 */
+  then: EventCommand[];
+  /** 条件を満たさなかった場合に実行するコマンド列 */
+  else?: EventCommand[];
+}
+
+/** パーティを回復 */
+export interface HealCommand {
+  type: "heal";
+}
+
+/** アイテムを付与 */
+export interface GiveItemCommand {
+  type: "give_item";
+  itemId: string;
+  quantity: number;
+}
+
+/** バトルを開始 */
+export interface BattleCommand {
+  type: "battle";
+  trainerName: string;
+  /** トレーナーのパーティ（speciesIdとlevelのペア配列） */
+  party: { speciesId: string; level: number }[];
+}
+
+/** プレイヤーを移動 */
+export interface MovePlayerCommand {
+  type: "move_player";
+  mapId: string;
+  x: number;
+  y: number;
+}
+
+/** 待機（演出用） */
+export interface WaitCommand {
+  type: "wait";
+  ms: number;
+}
+
+/** 全コマンドの直和型 */
+export type EventCommand =
+  | DialogueCommand
+  | SetFlagCommand
+  | BranchCommand
+  | HealCommand
+  | GiveItemCommand
+  | BattleCommand
+  | MovePlayerCommand
+  | WaitCommand;
+
+/** イベントスクリプト定義 */
+export interface EventScript {
+  id: string;
+  /** スクリプトを実行するための条件（未設定なら常に実行可能） */
+  trigger?: FlagRequirement;
+  /** コマンド列 */
+  commands: EventCommand[];
+}
+
+// ── スクリプトランナー ──
+
+/** スクリプト実行時に外部に通知するイベント */
+export type EventOutput =
+  | { type: "dialogue"; speaker?: string; lines: string[] }
+  | { type: "set_flag"; flag: string; value: boolean }
+  | { type: "heal" }
+  | { type: "give_item"; itemId: string; quantity: number }
+  | { type: "battle"; trainerName: string; party: { speciesId: string; level: number }[] }
+  | { type: "move_player"; mapId: string; x: number; y: number }
+  | { type: "wait"; ms: number };
+
+/**
+ * スクリプトが実行可能か判定
+ */
+export function canTriggerScript(script: EventScript, flags: StoryFlags): boolean {
+  if (!script.trigger) return true;
+  return checkFlagRequirement(flags, script.trigger);
+}
+
+/**
+ * コマンド列を平坦化して実行（分岐を解決する）
+ * @param commands 実行するコマンド列
+ * @param flags 現在のストーリーフラグ（分岐解決に使用）
+ * @returns 実行すべきEventOutputのリスト
+ */
+export function resolveCommands(commands: EventCommand[], flags: StoryFlags): EventOutput[] {
+  const outputs: EventOutput[] = [];
+  // フラグはスクリプト実行中にも変化する可能性があるので、ミュータブルコピーを使用
+  const mutableFlags = { ...flags };
+
+  for (const cmd of commands) {
+    switch (cmd.type) {
+      case "dialogue":
+        outputs.push({ type: "dialogue", speaker: cmd.speaker, lines: cmd.lines });
+        break;
+
+      case "set_flag":
+        mutableFlags[cmd.flag] = cmd.value;
+        outputs.push({ type: "set_flag", flag: cmd.flag, value: cmd.value });
+        break;
+
+      case "branch": {
+        const conditionMet = checkFlagRequirement(mutableFlags, cmd.condition);
+        const branch = conditionMet ? cmd.then : (cmd.else ?? []);
+        outputs.push(...resolveCommands(branch, mutableFlags));
+        break;
+      }
+
+      case "heal":
+        outputs.push({ type: "heal" });
+        break;
+
+      case "give_item":
+        outputs.push({ type: "give_item", itemId: cmd.itemId, quantity: cmd.quantity });
+        break;
+
+      case "battle":
+        outputs.push({ type: "battle", trainerName: cmd.trainerName, party: cmd.party });
+        break;
+
+      case "move_player":
+        outputs.push({ type: "move_player", mapId: cmd.mapId, x: cmd.x, y: cmd.y });
+        break;
+
+      case "wait":
+        outputs.push({ type: "wait", ms: cmd.ms });
+        break;
+    }
+  }
+
+  return outputs;
+}
+
+/**
+ * スクリプトを実行してイベント出力リストを取得
+ * @returns トリガー条件を満たさない場合はnull
+ */
+export function executeScript(script: EventScript, flags: StoryFlags): EventOutput[] | null {
+  if (!canTriggerScript(script, flags)) return null;
+  return resolveCommands(script.commands, flags);
+}


### PR DESCRIPTION
## Summary
- **イベントスクリプトエンジン** (`event-script.ts`): 会話・カットシーン・分岐をスクリプトとして記述・実行するエンジン
- **8種のコマンド**: `dialogue`, `set_flag`, `branch`, `heal`, `give_item`, `battle`, `move_player`, `wait`
- **分岐解決**: `resolveCommands()` がストーリーフラグに基づく条件分岐（ネスト対応）を解決し、フラットなイベント出力列を生成
- **実行中フラグ反映**: スクリプト実行中の `set_flag` が後続 `branch` に即時反映

Closes #42

## Test plan
- [x] 全254テスト通過（新規22テスト含む）
- [x] `bun run type-check` クリーン
- [x] `bun run lint` エラー/警告なし
- [x] `bun run build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)