### PR TITLE
feat: 進行ゲートの実装 (#60)

### DIFF
--- a/src/engine/map/map-data.ts
+++ b/src/engine/map/map-data.ts
@@ -23,6 +23,10 @@ export interface MapConnection {
   /** 接続元の座標範囲（ドアや出入口の位置） */
   sourceX: number;
   sourceY: number;
+  /** 通過に必要なフラグ条件（未設定なら常に通過可能） */
+  requirement?: FlagRequirement;
+  /** 条件未達時に表示するメッセージ */
+  blockedMessage?: string;
 }
 
 /** 野生モンスター出現テーブルのエントリ */


### PR DESCRIPTION
## Summary
- **MapConnection拡張**: `requirement`（FlagRequirement）と`blockedMessage`フィールドを追加
- **movePlayer拡張**: `storyFlags`引数を追加し、マップ接続のゲート条件をチェック。条件未達ならブロック＋メッセージ表示
- **MoveResult拡張**: `blockedMessage`フィールドを追加

Closes #60

## Test plan
- [x] 全259テスト通過（新規5テスト含む）
- [x] `bun run type-check` クリーン
- [x] `bun run lint` エラー/警告なし
- [x] `bun run build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)