### PR TITLE
feat: ジム戦イベントフロー + 監査バグ修正 (#46)

### DIFF
--- a/src/engine/battle/move-executor.ts
+++ b/src/engine/battle/move-executor.ts
@@ -132,7 +132,7 @@ export function executeMove(
   let statusApplied: StatusCondition | null = null;
   if (
     move.effect?.statusCondition &&
-    move.effect.statusChance &&
+    move.effect.statusChance !== undefined &&
     defender.status === null &&
     defenderHpAfter > 0
   ) {

--- a/src/engine/event/__tests__/gym.test.ts
+++ b/src/engine/event/__tests__/gym.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from "vitest";
+import {
+  createGymBattleScript,
+  getGymFlagName,
+  getGymEntryFlagName,
+  canChallengeGym,
+  getEarnedBadges,
+  canChallengeEliteFour,
+  getRequiredBadgeCount,
+} from "../gym";
+import type { GymDefinition } from "../gym";
+import { executeScript } from "../event-script";
+import type { StoryFlags } from "@/engine/state/story-flags";
+
+const testGym: GymDefinition = {
+  id: "gym-1",
+  gymNumber: 1,
+  name: "いわジム",
+  leaderName: "タケシ",
+  type: "rock",
+  leaderParty: [
+    { speciesId: "geodude", level: 12 },
+    { speciesId: "onix", level: 14 },
+  ],
+  badgeName: "グレーバッジ",
+  mapId: "gym-1-map",
+  leaderIntroDialogue: [
+    "ようこそ、いわジムへ！",
+    "お前の実力を見せてもらおう！",
+  ],
+  leaderDefeatDialogue: [
+    "やるな…お前の実力を認めよう。",
+    "このバッジを受け取ってくれ。",
+  ],
+  rewardItemId: "tm-rock-throw",
+};
+
+const testGym3: GymDefinition = {
+  id: "gym-3",
+  gymNumber: 3,
+  name: "でんきジム",
+  leaderName: "マチス",
+  type: "electric",
+  leaderParty: [{ speciesId: "voltorb", level: 21 }],
+  badgeName: "オレンジバッジ",
+  mapId: "gym-3-map",
+  leaderIntroDialogue: ["覚悟はいいか！"],
+  leaderDefeatDialogue: ["ビリビリだぜ！"],
+};
+
+describe("getGymFlagName / getGymEntryFlagName", () => {
+  it("ジムクリアフラグ名を生成する", () => {
+    expect(getGymFlagName(1)).toBe("gym1_cleared");
+    expect(getGymFlagName(8)).toBe("gym8_cleared");
+  });
+
+  it("ジム入場フラグ名を生成する", () => {
+    expect(getGymEntryFlagName(1)).toBe("gym1_entered");
+    expect(getGymEntryFlagName(5)).toBe("gym5_entered");
+  });
+});
+
+describe("getRequiredBadgeCount", () => {
+  it("ジム1は前提バッジ0", () => {
+    expect(getRequiredBadgeCount(1)).toBe(0);
+  });
+
+  it("ジム3は前提バッジ2", () => {
+    expect(getRequiredBadgeCount(3)).toBe(2);
+  });
+
+  it("ジム8は前提バッジ7", () => {
+    expect(getRequiredBadgeCount(8)).toBe(7);
+  });
+});
+
+describe("canChallengeGym", () => {
+  it("ジム1は常に挑戦可能", () => {
+    expect(canChallengeGym(1, {})).toBe(true);
+  });
+
+  it("ジム2はジム1クリアが必要", () => {
+    expect(canChallengeGym(2, {})).toBe(false);
+    expect(canChallengeGym(2, { gym1_cleared: true })).toBe(true);
+  });
+
+  it("ジム3はジム1,2両方のクリアが必要", () => {
+    expect(canChallengeGym(3, { gym1_cleared: true })).toBe(false);
+    expect(canChallengeGym(3, { gym1_cleared: true, gym2_cleared: true })).toBe(true);
+  });
+
+  it("ジム8はジム1-7の全クリアが必要", () => {
+    const flags: StoryFlags = {};
+    for (let i = 1; i <= 7; i++) {
+      flags[`gym${i}_cleared`] = true;
+    }
+    expect(canChallengeGym(8, flags)).toBe(true);
+
+    // 1つ欠けるとダメ
+    delete flags.gym4_cleared;
+    expect(canChallengeGym(8, flags)).toBe(false);
+  });
+});
+
+describe("getEarnedBadges", () => {
+  it("バッジなしの場合は空配列", () => {
+    expect(getEarnedBadges({})).toEqual([]);
+  });
+
+  it("クリア済みジムのバッジ番号を返す", () => {
+    const flags: StoryFlags = {
+      gym1_cleared: true,
+      gym3_cleared: true,
+      gym5_cleared: true,
+    };
+    expect(getEarnedBadges(flags)).toEqual([1, 3, 5]);
+  });
+
+  it("全8バッジ取得", () => {
+    const flags: StoryFlags = {};
+    for (let i = 1; i <= 8; i++) {
+      flags[`gym${i}_cleared`] = true;
+    }
+    expect(getEarnedBadges(flags)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+  });
+});
+
+describe("canChallengeEliteFour", () => {
+  it("バッジ不足では挑戦不可", () => {
+    const flags: StoryFlags = {
+      gym1_cleared: true,
+      gym2_cleared: true,
+    };
+    expect(canChallengeEliteFour(flags)).toBe(false);
+  });
+
+  it("全8バッジで挑戦可能", () => {
+    const flags: StoryFlags = {};
+    for (let i = 1; i <= 8; i++) {
+      flags[`gym${i}_cleared`] = true;
+    }
+    expect(canChallengeEliteFour(flags)).toBe(true);
+  });
+
+  it("カスタムジム数対応", () => {
+    const flags: StoryFlags = {
+      gym1_cleared: true,
+      gym2_cleared: true,
+      gym3_cleared: true,
+    };
+    expect(canChallengeEliteFour(flags, 3)).toBe(true);
+    expect(canChallengeEliteFour(flags, 4)).toBe(false);
+  });
+});
+
+describe("createGymBattleScript", () => {
+  it("未クリア時のスクリプトにバトルとバッジ獲得が含まれる", () => {
+    const script = createGymBattleScript(testGym);
+    expect(script.id).toBe("gym_battle_1");
+
+    const outputs = executeScript(script, {})!;
+    expect(outputs).not.toBeNull();
+
+    // リーダー会話
+    expect(outputs[0]).toEqual({
+      type: "dialogue",
+      speaker: "タケシ",
+      lines: ["ようこそ、いわジムへ！", "お前の実力を見せてもらおう！"],
+    });
+
+    // バトル
+    expect(outputs[1]).toEqual({
+      type: "battle",
+      trainerName: "タケシ",
+      party: [
+        { speciesId: "geodude", level: 12 },
+        { speciesId: "onix", level: 14 },
+      ],
+    });
+
+    // 勝利会話
+    expect(outputs[2]).toEqual({
+      type: "dialogue",
+      speaker: "タケシ",
+      lines: ["やるな…お前の実力を認めよう。", "このバッジを受け取ってくれ。"],
+    });
+
+    // バッジ獲得メッセージ
+    expect(outputs[3]).toEqual({
+      type: "dialogue",
+      speaker: undefined,
+      lines: ["グレーバッジを手に入れた！"],
+    });
+
+    // 報酬アイテム
+    expect(outputs[4]).toEqual({
+      type: "give_item",
+      itemId: "tm-rock-throw",
+      quantity: 1,
+    });
+
+    // クリアフラグ
+    expect(outputs[5]).toEqual({
+      type: "set_flag",
+      flag: "gym1_cleared",
+      value: true,
+    });
+  });
+
+  it("クリア済みの場合は短い会話のみ", () => {
+    const script = createGymBattleScript(testGym);
+    const outputs = executeScript(script, { gym1_cleared: true })!;
+
+    expect(outputs).toHaveLength(1);
+    expect(outputs[0]).toEqual({
+      type: "dialogue",
+      speaker: "タケシ",
+      lines: ["また来たのか。お前の実力は認めている。先に進むがいい。"],
+    });
+  });
+
+  it("報酬アイテムなしのジムスクリプト", () => {
+    const script = createGymBattleScript(testGym3);
+    const outputs = executeScript(script, {})!;
+
+    // battle(1) + dialogue前(1) + dialogue後(1) + badge(1) + flag(1) = 5
+    expect(outputs).toHaveLength(5);
+
+    // give_item が含まれない
+    const itemOutputs = outputs.filter((o) => o.type === "give_item");
+    expect(itemOutputs).toHaveLength(0);
+
+    // フラグは gym3_cleared
+    const flagOutput = outputs.find((o) => o.type === "set_flag");
+    expect(flagOutput).toEqual({
+      type: "set_flag",
+      flag: "gym3_cleared",
+      value: true,
+    });
+  });
+});

--- a/src/engine/event/gym.ts
+++ b/src/engine/event/gym.ts
@@ -1,0 +1,177 @@
+/**
+ * ジム戦イベントフロー (#46)
+ * パズル → リーダー戦 → バッジ獲得のフローを定義
+ */
+
+import type { EventScript, EventCommand } from "./event-script";
+
+/** ジムリーダーのパーティメンバー定義 */
+export interface GymLeaderPartyMember {
+  speciesId: string;
+  level: number;
+}
+
+/** ジム定義 */
+export interface GymDefinition {
+  id: string;
+  /** ジム番号（1-8） */
+  gymNumber: number;
+  /** ジム名 */
+  name: string;
+  /** ジムリーダー名 */
+  leaderName: string;
+  /** ジムのタイプ */
+  type: string;
+  /** リーダーのパーティ */
+  leaderParty: GymLeaderPartyMember[];
+  /** 獲得するバッジ名 */
+  badgeName: string;
+  /** ジムのマップID */
+  mapId: string;
+  /** 入場に必要なフラグ条件（未設定なら常に入場可能） */
+  entryRequirement?: string[];
+  /** リーダー戦前の会話 */
+  leaderIntroDialogue: string[];
+  /** リーダー戦後（勝利時）の会話 */
+  leaderDefeatDialogue: string[];
+  /** バッジ獲得時の報酬技マシンなど */
+  rewardItemId?: string;
+}
+
+/**
+ * ジムのストーリーフラグ名を生成
+ */
+export function getGymFlagName(gymNumber: number): string {
+  return `gym${gymNumber}_cleared`;
+}
+
+/**
+ * ジムの入場フラグ名を生成
+ */
+export function getGymEntryFlagName(gymNumber: number): string {
+  return `gym${gymNumber}_entered`;
+}
+
+/**
+ * ジムリーダー戦のイベントスクリプトを生成
+ * フロー: リーダー会話 → バトル → 勝利会話 → バッジ獲得 → フラグ設定
+ */
+export function createGymBattleScript(gym: GymDefinition): EventScript {
+  const clearedFlag = getGymFlagName(gym.gymNumber);
+
+  const commands: EventCommand[] = [
+    // 既にクリア済みの場合は短い会話で終了
+    {
+      type: "branch",
+      condition: clearedFlag,
+      then: [
+        {
+          type: "dialogue",
+          speaker: gym.leaderName,
+          lines: ["また来たのか。お前の実力は認めている。先に進むがいい。"],
+        },
+      ],
+      else: [
+        // リーダー戦前の会話
+        {
+          type: "dialogue",
+          speaker: gym.leaderName,
+          lines: gym.leaderIntroDialogue,
+        },
+        // バトル開始
+        {
+          type: "battle",
+          trainerName: gym.leaderName,
+          party: gym.leaderParty,
+        },
+        // 勝利後の会話
+        {
+          type: "dialogue",
+          speaker: gym.leaderName,
+          lines: gym.leaderDefeatDialogue,
+        },
+        // バッジ獲得
+        {
+          type: "dialogue",
+          lines: [`${gym.badgeName}を手に入れた！`],
+        },
+        // 報酬アイテム（あれば）
+        ...(gym.rewardItemId
+          ? [
+              {
+                type: "give_item" as const,
+                itemId: gym.rewardItemId,
+                quantity: 1,
+              },
+            ]
+          : []),
+        // クリアフラグ設定
+        {
+          type: "set_flag" as const,
+          flag: clearedFlag,
+          value: true,
+        },
+      ],
+    },
+  ];
+
+  return {
+    id: `gym_battle_${gym.gymNumber}`,
+    // 未クリアでも再訪可能（branch内で分岐するため、triggerは設定しない）
+    commands,
+  };
+}
+
+/**
+ * ジムクリアに必要なバッジ数を判定
+ * @param gymNumber ジム番号（1-8）
+ * @returns 入場に必要な前提バッジ数（0-7）
+ */
+export function getRequiredBadgeCount(gymNumber: number): number {
+  // 最初のジムは前提なし、以降は前のジムのクリアが必要
+  return Math.max(0, gymNumber - 1);
+}
+
+/**
+ * プレイヤーが特定のジムに挑戦可能か判定
+ * @param gymNumber ジム番号
+ * @param storyFlags 現在のストーリーフラグ
+ */
+export function canChallengeGym(
+  gymNumber: number,
+  storyFlags: Record<string, boolean>,
+): boolean {
+  const requiredBadges = getRequiredBadgeCount(gymNumber);
+  for (let i = 1; i <= requiredBadges; i++) {
+    if (!storyFlags[getGymFlagName(i)]) return false;
+  }
+  return true;
+}
+
+/**
+ * クリア済みバッジの一覧を取得
+ * @param storyFlags 現在のストーリーフラグ
+ * @param totalGyms ジム総数（デフォルト8）
+ */
+export function getEarnedBadges(
+  storyFlags: Record<string, boolean>,
+  totalGyms: number = 8,
+): number[] {
+  const badges: number[] = [];
+  for (let i = 1; i <= totalGyms; i++) {
+    if (storyFlags[getGymFlagName(i)]) {
+      badges.push(i);
+    }
+  }
+  return badges;
+}
+
+/**
+ * 四天王に挑戦可能か判定（全8バッジ必要）
+ */
+export function canChallengeEliteFour(
+  storyFlags: Record<string, boolean>,
+  totalGyms: number = 8,
+): boolean {
+  return getEarnedBadges(storyFlags, totalGyms).length >= totalGyms;
+}

--- a/src/engine/state/save-data.ts
+++ b/src/engine/state/save-data.ts
@@ -139,9 +139,11 @@ export function validateSaveData(data: unknown): data is SaveData {
 
   const player = state.player as Record<string, unknown>;
   if (typeof player.name !== "string") return false;
-  if (!Array.isArray(player.partyState)) {
-    if (typeof player.partyState !== "object" || player.partyState === null) return false;
-  }
+  if (typeof player.partyState !== "object" || player.partyState === null) return false;
+
+  const ps = player.partyState as Record<string, unknown>;
+  if (!Array.isArray(ps.party)) return false;
+  if (!Array.isArray(ps.boxes)) return false;
 
   return true;
 }


### PR DESCRIPTION
## Summary
- **ジム戦イベントフロー** (`gym.ts`): EventScript上に構築されたジム戦システム
  - `GymDefinition`: ジム定義型（リーダー名、パーティ、バッジ、報酬）
  - `createGymBattleScript()`: 会話→バトル→勝利→バッジ獲得→フラグのEventScriptを自動生成
  - `canChallengeGym()`: バッジ数による挑戦可否判定
  - `canChallengeEliteFour()`: 全バッジ取得で四天王挑戦可能
  - クリア済み再訪時は短い会話のみに分岐
- **監査バグ修正**:
  - `move-executor.ts`: `statusChance=0` のfalsy評価を `!== undefined` に修正
  - `save-data.ts`: `validateSaveData` で `partyState.party/boxes` の配列検証を追加

Closes #46

## Test plan
- [x] 全277テスト通過（新規18テスト含む）
- [x] `bun run type-check` クリーン
- [x] `bun run lint` エラー/警告なし
- [x] `bun run build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)