### PR TITLE
feat: BGM管理システム (#75)

### DIFF
--- a/src/engine/audio/__tests__/bgm-manager.test.ts
+++ b/src/engine/audio/__tests__/bgm-manager.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect } from "vitest";
+import { createBgmManager, resolveMapBgm, resolveBattleBgm } from "../bgm-manager";
+
+describe("createBgmManager", () => {
+  it("初期状態は再生なし", () => {
+    const mgr = createBgmManager();
+    const state = mgr.getState();
+    expect(state.currentTrackId).toBeNull();
+    expect(state.isPlaying).toBe(false);
+    expect(state.volume).toBe(0.7);
+    expect(state.isFading).toBe(false);
+  });
+
+  describe("play", () => {
+    it("BGMを再生開始する", () => {
+      const mgr = createBgmManager();
+      mgr.play("town-1");
+      const state = mgr.getState();
+      expect(state.currentTrackId).toBe("town-1");
+      expect(state.isPlaying).toBe(true);
+      expect(mgr.getEventLog()).toEqual([{ type: "play", trackId: "town-1" }]);
+    });
+
+    it("同じトラック再生中は何もしない", () => {
+      const mgr = createBgmManager();
+      mgr.play("town-1");
+      mgr.clearEventLog();
+      mgr.play("town-1");
+      expect(mgr.getEventLog()).toEqual([]);
+    });
+
+    it("別トラックに切り替え時は先にstopが発行される", () => {
+      const mgr = createBgmManager();
+      mgr.play("town-1");
+      mgr.clearEventLog();
+      mgr.play("route-1");
+      expect(mgr.getEventLog()).toEqual([
+        { type: "stop" },
+        { type: "play", trackId: "route-1" },
+      ]);
+      expect(mgr.getState().currentTrackId).toBe("route-1");
+    });
+  });
+
+  describe("stop", () => {
+    it("再生中のBGMを停止する", () => {
+      const mgr = createBgmManager();
+      mgr.play("town-1");
+      mgr.clearEventLog();
+      mgr.stop();
+      expect(mgr.getState().isPlaying).toBe(false);
+      expect(mgr.getState().currentTrackId).toBeNull();
+      expect(mgr.getEventLog()).toEqual([{ type: "stop" }]);
+    });
+
+    it("再生していない場合は何もしない", () => {
+      const mgr = createBgmManager();
+      mgr.stop();
+      expect(mgr.getEventLog()).toEqual([]);
+    });
+  });
+
+  describe("pause / resume", () => {
+    it("一時停止と再開ができる", () => {
+      const mgr = createBgmManager();
+      mgr.play("town-1");
+      mgr.clearEventLog();
+
+      mgr.pause();
+      expect(mgr.getState().isPlaying).toBe(false);
+      expect(mgr.getState().currentTrackId).toBe("town-1");
+
+      mgr.resume();
+      expect(mgr.getState().isPlaying).toBe(true);
+      expect(mgr.getEventLog()).toEqual([{ type: "pause" }, { type: "resume" }]);
+    });
+
+    it("再生していない時のpauseは何もしない", () => {
+      const mgr = createBgmManager();
+      mgr.pause();
+      expect(mgr.getEventLog()).toEqual([]);
+    });
+
+    it("トラックがない時のresumeは何もしない", () => {
+      const mgr = createBgmManager();
+      mgr.resume();
+      expect(mgr.getEventLog()).toEqual([]);
+    });
+  });
+
+  describe("fadeOut", () => {
+    it("フェードアウトイベントを発行する", () => {
+      const mgr = createBgmManager();
+      mgr.play("town-1");
+      mgr.clearEventLog();
+      mgr.fadeOut(1000);
+      expect(mgr.getState().isFading).toBe(true);
+      expect(mgr.getEventLog()).toEqual([{ type: "fade_out", durationMs: 1000 }]);
+    });
+
+    it("再生していない場合は何もしない", () => {
+      const mgr = createBgmManager();
+      mgr.fadeOut(1000);
+      expect(mgr.getEventLog()).toEqual([]);
+    });
+  });
+
+  describe("fadeIn", () => {
+    it("フェードインで新トラックを再生する", () => {
+      const mgr = createBgmManager();
+      mgr.fadeIn("battle-wild", 500);
+      expect(mgr.getState().currentTrackId).toBe("battle-wild");
+      expect(mgr.getState().isPlaying).toBe(true);
+      expect(mgr.getState().isFading).toBe(true);
+      expect(mgr.getEventLog()).toEqual([
+        { type: "fade_in", trackId: "battle-wild", durationMs: 500 },
+      ]);
+    });
+
+    it("別トラック再生中は先にstopが発行される", () => {
+      const mgr = createBgmManager();
+      mgr.play("town-1");
+      mgr.clearEventLog();
+      mgr.fadeIn("battle-wild", 500);
+      expect(mgr.getEventLog()).toEqual([
+        { type: "stop" },
+        { type: "fade_in", trackId: "battle-wild", durationMs: 500 },
+      ]);
+    });
+  });
+
+  describe("crossFade", () => {
+    it("クロスフェードでトラックを切り替える", () => {
+      const mgr = createBgmManager();
+      mgr.play("town-1");
+      mgr.clearEventLog();
+      mgr.crossFade("route-1", 1000);
+      expect(mgr.getEventLog()).toEqual([
+        { type: "fade_out", durationMs: 500 },
+        { type: "fade_in", trackId: "route-1", durationMs: 500 },
+      ]);
+      expect(mgr.getState().currentTrackId).toBe("route-1");
+    });
+
+    it("同じトラック再生中は何もしない", () => {
+      const mgr = createBgmManager();
+      mgr.play("town-1");
+      mgr.clearEventLog();
+      mgr.crossFade("town-1", 1000);
+      expect(mgr.getEventLog()).toEqual([]);
+    });
+
+    it("停止中からのcrossFadeはfade_inのみ", () => {
+      const mgr = createBgmManager();
+      mgr.crossFade("town-1", 1000);
+      expect(mgr.getEventLog()).toEqual([
+        { type: "fade_in", trackId: "town-1", durationMs: 500 },
+      ]);
+    });
+  });
+
+  describe("setVolume", () => {
+    it("音量を設定する", () => {
+      const mgr = createBgmManager();
+      mgr.setVolume(0.5);
+      expect(mgr.getState().volume).toBe(0.5);
+      expect(mgr.getEventLog()).toEqual([{ type: "volume_change", volume: 0.5 }]);
+    });
+
+    it("音量は0-1にクランプされる", () => {
+      const mgr = createBgmManager();
+      mgr.setVolume(-0.5);
+      expect(mgr.getState().volume).toBe(0);
+
+      mgr.setVolume(1.5);
+      expect(mgr.getState().volume).toBe(1);
+    });
+  });
+
+  describe("onFadeComplete", () => {
+    it("フェード完了でisFadingがfalseになる", () => {
+      const mgr = createBgmManager();
+      mgr.play("town-1");
+      mgr.fadeOut(1000);
+      expect(mgr.getState().isFading).toBe(true);
+
+      mgr.onFadeComplete();
+      expect(mgr.getState().isFading).toBe(false);
+    });
+  });
+});
+
+describe("resolveMapBgm", () => {
+  const mapBgmTable: Record<string, string> = {
+    "town-1": "bgm-town-peaceful",
+    "route-1": "bgm-route-adventure",
+    "gym-1": "bgm-gym",
+  };
+
+  it("マップIDに対応するBGMを返す", () => {
+    expect(resolveMapBgm("town-1", mapBgmTable)).toBe("bgm-town-peaceful");
+    expect(resolveMapBgm("route-1", mapBgmTable)).toBe("bgm-route-adventure");
+  });
+
+  it("マッピングにないマップはデフォルトを返す", () => {
+    expect(resolveMapBgm("unknown-map", mapBgmTable)).toBe("overworld-default");
+  });
+
+  it("カスタムデフォルトを指定できる", () => {
+    expect(resolveMapBgm("unknown", mapBgmTable, "bgm-fallback")).toBe("bgm-fallback");
+  });
+});
+
+describe("resolveBattleBgm", () => {
+  it("野生バトルBGMを返す", () => {
+    expect(resolveBattleBgm("wild")).toBe("battle-wild");
+  });
+
+  it("トレーナーバトルBGMを返す", () => {
+    expect(resolveBattleBgm("trainer")).toBe("battle-trainer");
+  });
+
+  it("ジムリーダーBGMを返す", () => {
+    expect(resolveBattleBgm("trainer", true)).toBe("battle-gym");
+  });
+
+  it("四天王BGMを返す（最優先）", () => {
+    expect(resolveBattleBgm("trainer", true, true)).toBe("battle-elite");
+    expect(resolveBattleBgm("trainer", false, true)).toBe("battle-elite");
+  });
+});

--- a/src/engine/audio/bgm-manager.ts
+++ b/src/engine/audio/bgm-manager.ts
@@ -1,0 +1,211 @@
+/**
+ * BGM管理システム (#75)
+ * 場面に応じたBGMの再生・切替・フェードを管理する
+ */
+
+/** BGMトラックの場面種別 */
+export type BgmContext =
+  | "title"
+  | "overworld"
+  | "battle_wild"
+  | "battle_trainer"
+  | "battle_gym"
+  | "battle_elite"
+  | "victory"
+  | "healing"
+  | "evolution"
+  | "event";
+
+/** BGMトラック定義 */
+export interface BgmTrack {
+  id: string;
+  /** 表示名 */
+  name: string;
+  /** 場面種別 */
+  context: BgmContext;
+  /** 音声ファイルのパス（相対パス） */
+  src: string;
+  /** ループするか */
+  loop: boolean;
+  /** デフォルト音量（0.0-1.0） */
+  volume: number;
+}
+
+/** BGMマネージャーの状態 */
+export interface BgmState {
+  currentTrackId: string | null;
+  isPlaying: boolean;
+  volume: number;
+  isFading: boolean;
+}
+
+/** BGMマネージャーが発行するイベント */
+export type BgmEvent =
+  | { type: "play"; trackId: string }
+  | { type: "stop" }
+  | { type: "pause" }
+  | { type: "resume" }
+  | { type: "fade_out"; durationMs: number }
+  | { type: "fade_in"; trackId: string; durationMs: number }
+  | { type: "volume_change"; volume: number };
+
+/**
+ * BGMマネージャー
+ * 実際のオーディオ再生はUIレイヤーに委譲し、ここではロジックのみを管理する
+ */
+export function createBgmManager() {
+  let state: BgmState = {
+    currentTrackId: null,
+    isPlaying: false,
+    volume: 0.7,
+    isFading: false,
+  };
+
+  const eventLog: BgmEvent[] = [];
+
+  function emit(event: BgmEvent) {
+    eventLog.push(event);
+  }
+
+  return {
+    /** 現在の状態を取得 */
+    getState(): BgmState {
+      return { ...state };
+    },
+
+    /** イベントログを取得（テスト用） */
+    getEventLog(): BgmEvent[] {
+      return [...eventLog];
+    },
+
+    /** イベントログをクリア */
+    clearEventLog() {
+      eventLog.length = 0;
+    },
+
+    /**
+     * BGMを再生（現在のトラックと同じなら何もしない）
+     */
+    play(trackId: string): void {
+      if (state.currentTrackId === trackId && state.isPlaying) return;
+
+      if (state.currentTrackId && state.currentTrackId !== trackId) {
+        emit({ type: "stop" });
+      }
+
+      state = {
+        ...state,
+        currentTrackId: trackId,
+        isPlaying: true,
+        isFading: false,
+      };
+      emit({ type: "play", trackId });
+    },
+
+    /** BGMを停止 */
+    stop(): void {
+      if (!state.isPlaying) return;
+      state = { ...state, currentTrackId: null, isPlaying: false, isFading: false };
+      emit({ type: "stop" });
+    },
+
+    /** BGMを一時停止 */
+    pause(): void {
+      if (!state.isPlaying) return;
+      state = { ...state, isPlaying: false };
+      emit({ type: "pause" });
+    },
+
+    /** BGMを再開 */
+    resume(): void {
+      if (state.isPlaying || !state.currentTrackId) return;
+      state = { ...state, isPlaying: true };
+      emit({ type: "resume" });
+    },
+
+    /**
+     * フェードアウトして停止
+     */
+    fadeOut(durationMs: number): void {
+      if (!state.isPlaying) return;
+      state = { ...state, isFading: true };
+      emit({ type: "fade_out", durationMs });
+      // 実際のフェード完了はUIレイヤーがstop()を呼ぶ
+    },
+
+    /**
+     * フェードインで新しいトラックを再生
+     */
+    fadeIn(trackId: string, durationMs: number): void {
+      if (state.currentTrackId && state.currentTrackId !== trackId) {
+        emit({ type: "stop" });
+      }
+      state = {
+        ...state,
+        currentTrackId: trackId,
+        isPlaying: true,
+        isFading: true,
+      };
+      emit({ type: "fade_in", trackId, durationMs });
+    },
+
+    /**
+     * クロスフェードで切り替え（フェードアウト→フェードイン）
+     */
+    crossFade(trackId: string, durationMs: number): void {
+      if (state.currentTrackId === trackId && state.isPlaying) return;
+
+      if (state.isPlaying) {
+        emit({ type: "fade_out", durationMs: Math.floor(durationMs / 2) });
+      }
+
+      state = {
+        ...state,
+        currentTrackId: trackId,
+        isPlaying: true,
+        isFading: true,
+      };
+      emit({ type: "fade_in", trackId, durationMs: Math.floor(durationMs / 2) });
+    },
+
+    /** 音量設定（0.0-1.0） */
+    setVolume(volume: number): void {
+      const clamped = Math.max(0, Math.min(1, volume));
+      state = { ...state, volume: clamped };
+      emit({ type: "volume_change", volume: clamped });
+    },
+
+    /** フェード完了通知（UIレイヤーから呼ばれる） */
+    onFadeComplete(): void {
+      state = { ...state, isFading: false };
+    },
+  };
+}
+
+/**
+ * マップIDからBGMトラックIDを解決する
+ * @param mapId マップID
+ * @param mapBgmTable マップ→BGMのマッピング
+ * @param defaultTrackId マッピングにない場合のデフォルト
+ */
+export function resolveMapBgm(
+  mapId: string,
+  mapBgmTable: Record<string, string>,
+  defaultTrackId: string = "overworld-default",
+): string {
+  return mapBgmTable[mapId] ?? defaultTrackId;
+}
+
+/**
+ * バトル種別からBGMトラックIDを解決する
+ */
+export function resolveBattleBgm(
+  battleType: "wild" | "trainer",
+  isGymLeader: boolean = false,
+  isEliteFour: boolean = false,
+): string {
+  if (isEliteFour) return "battle-elite";
+  if (isGymLeader) return "battle-gym";
+  if (battleType === "trainer") return "battle-trainer";
+  return "battle-wild";
+}


### PR DESCRIPTION
## Summary
- **BGMマネージャー** (`bgm-manager.ts`): 場面に応じたBGMの再生・切替・フェードを管理
  - `play()`, `stop()`, `pause()`, `resume()`: 基本操作
  - `fadeOut()`, `fadeIn()`, `crossFade()`: フェード付き切替
  - イベントログ方式で実際のオーディオ再生はUIレイヤーに委譲（テスタブル）
- **BGM解決ユーティリティ**:
  - `resolveMapBgm()`: マップID → BGMトラックIDマッピング
  - `resolveBattleBgm()`: バトル種別（野生/トレーナー/ジム/四天王）のBGM解決
- **型定義**: `BgmTrack`, `BgmContext`, `BgmState`, `BgmEvent`

Closes #75

## Test plan
- [x] 全303テスト通過（新規26テスト含む）
- [x] `bun run type-check` クリーン
- [x] `bun run lint` エラー/警告なし
- [x] `bun run build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)