### PR TITLE
feat: エンディングシーケンスの実装 (#56)

### DIFF
--- a/src/engine/event/__tests__/ending.test.ts
+++ b/src/engine/event/__tests__/ending.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest";
+import { executeScript } from "../event-script";
+import {
+  createEndingScript,
+  createPostgameIntroScript,
+  createSoumaFinalBattleScript,
+} from "../ending";
+
+describe("エンディングシーケンス", () => {
+  describe("createEndingScript", () => {
+    it("champion_defeatedフラグでトリガーされる", () => {
+      const script = createEndingScript("テスト");
+      expect(executeScript(script, {})).toBeNull();
+      expect(executeScript(script, { champion_defeated: true })).not.toBeNull();
+    });
+
+    it("殿堂入りメッセージにプレイヤー名が含まれる", () => {
+      const script = createEndingScript("ヒロト");
+      const outputs = executeScript(script, { champion_defeated: true })!;
+      const firstDialogue = outputs[0];
+      expect(firstDialogue.type).toBe("dialogue");
+      if (firstDialogue.type === "dialogue") {
+        expect(firstDialogue.lines[0]).toContain("ヒロト");
+      }
+    });
+
+    it("アカツキ、母、博士、ソウマの会話を含む", () => {
+      const script = createEndingScript("テスト");
+      const outputs = executeScript(script, { champion_defeated: true })!;
+
+      const speakers = outputs
+        .filter((o) => o.type === "dialogue" && "speaker" in o && o.speaker)
+        .map((o) => (o as { speaker: string }).speaker);
+
+      expect(speakers).toContain("アカツキ");
+      expect(speakers).toContain("母");
+      expect(speakers).toContain("コダチ博士");
+      expect(speakers).toContain("ソウマ");
+    });
+
+    it("コダマ町への移動を含む", () => {
+      const script = createEndingScript("テスト");
+      const outputs = executeScript(script, { champion_defeated: true })!;
+
+      const movePlayer = outputs.find((o) => o.type === "move_player");
+      expect(movePlayer).toBeDefined();
+      if (movePlayer && movePlayer.type === "move_player") {
+        expect(movePlayer.mapId).toBe("kodama-town");
+      }
+    });
+
+    it("ending_completeフラグが設定される", () => {
+      const script = createEndingScript("テスト");
+      const outputs = executeScript(script, { champion_defeated: true })!;
+
+      const flag = outputs.find(
+        (o) => o.type === "set_flag" && o.flag === "ending_complete"
+      );
+      expect(flag).toEqual({
+        type: "set_flag",
+        flag: "ending_complete",
+        value: true,
+      });
+    });
+
+    it("パーティ回復を含む", () => {
+      const script = createEndingScript("テスト");
+      const outputs = executeScript(script, { champion_defeated: true })!;
+
+      const heal = outputs.find((o) => o.type === "heal");
+      expect(heal).toBeDefined();
+    });
+
+    it("演出用のwaitを含む", () => {
+      const script = createEndingScript("テスト");
+      const outputs = executeScript(script, { champion_defeated: true })!;
+
+      const waits = outputs.filter((o) => o.type === "wait");
+      expect(waits.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe("createPostgameIntroScript", () => {
+    it("エンディング完了後にトリガーされる", () => {
+      const script = createPostgameIntroScript();
+      expect(executeScript(script, { ending_complete: true, postgame_started: false })).not.toBeNull();
+    });
+
+    it("エンディング未完了ではトリガーされない", () => {
+      const script = createPostgameIntroScript();
+      expect(executeScript(script, {})).toBeNull();
+    });
+
+    it("既にポストゲーム開始済みならトリガーされない", () => {
+      const script = createPostgameIntroScript();
+      expect(executeScript(script, { ending_complete: true, postgame_started: true })).toBeNull();
+    });
+
+    it("postgame_startedフラグが設定される", () => {
+      const script = createPostgameIntroScript();
+      const outputs = executeScript(script, { ending_complete: true, postgame_started: false })!;
+
+      const flag = outputs.find((o) => o.type === "set_flag");
+      expect(flag).toEqual({
+        type: "set_flag",
+        flag: "postgame_started",
+        value: true,
+      });
+    });
+  });
+
+  describe("createSoumaFinalBattleScript", () => {
+    it("エンディング完了後にトリガーされる", () => {
+      const script = createSoumaFinalBattleScript();
+      expect(executeScript(script, { ending_complete: true, souma_final_beaten: false })).not.toBeNull();
+    });
+
+    it("ソウマとの6匹フルバトルを含む", () => {
+      const script = createSoumaFinalBattleScript();
+      const outputs = executeScript(script, { ending_complete: true, souma_final_beaten: false })!;
+
+      const battle = outputs.find((o) => o.type === "battle");
+      expect(battle).toBeDefined();
+      if (battle && battle.type === "battle") {
+        expect(battle.trainerName).toBe("モンスター研究者 ソウマ");
+        expect(battle.party).toHaveLength(6);
+        // レベル62-65の範囲
+        for (const mon of battle.party) {
+          expect(mon.level).toBeGreaterThanOrEqual(62);
+          expect(mon.level).toBeLessThanOrEqual(65);
+        }
+      }
+    });
+
+    it("souma_final_beatenフラグが設定される", () => {
+      const script = createSoumaFinalBattleScript();
+      const outputs = executeScript(script, { ending_complete: true, souma_final_beaten: false })!;
+
+      const flag = outputs.find((o) => o.type === "set_flag");
+      expect(flag).toEqual({
+        type: "set_flag",
+        flag: "souma_final_beaten",
+        value: true,
+      });
+    });
+
+    it("既に勝利済みならトリガーされない", () => {
+      const script = createSoumaFinalBattleScript();
+      expect(executeScript(script, { ending_complete: true, souma_final_beaten: true })).toBeNull();
+    });
+  });
+});

--- a/src/engine/event/ending.ts
+++ b/src/engine/event/ending.ts
@@ -1,0 +1,187 @@
+/**
+ * エンディングシーケンスの実装 (#56)
+ * チャンピオン勝利後のエンディング〜エピローグ
+ */
+
+import type { EventScript, EventCommand } from "./event-script";
+
+/**
+ * エンディングシーケンスのスクリプトを生成
+ * チャンピオン撃破後に呼ばれることを前提とする
+ */
+export function createEndingScript(playerName: string): EventScript {
+  return {
+    id: "ending_sequence",
+    trigger: "champion_defeated",
+    commands: [
+      // 殿堂入り
+      {
+        type: "dialogue",
+        lines: [
+          `${playerName}は殿堂入りした！`,
+          "あなたとモンスターたちの絆は、レムニアの歴史に刻まれた。",
+        ],
+      },
+
+      // アカツキとの会話
+      {
+        type: "dialogue",
+        speaker: "アカツキ",
+        lines: [
+          "私はあの日、全てを諦めた。",
+          "記憶が戻ることも、世界が変わることも、不可能だと思った。",
+          "だがお前は諦めなかった。",
+          "…ありがとう。お前のおかげで、私もまた前に進める。",
+        ],
+      },
+
+      // 演出用の待機
+      { type: "wait", ms: 2000 },
+
+      // スタッフロール演出
+      {
+        type: "dialogue",
+        lines: [
+          "— MONSTER CHRONICLE —",
+          "あなたの旅を振り返ります…",
+        ],
+      },
+      { type: "wait", ms: 3000 },
+
+      // エピローグ: コダマ町に戻る
+      {
+        type: "move_player",
+        mapId: "kodama-town",
+        x: 5,
+        y: 5,
+      },
+
+      // 母親との再会
+      {
+        type: "dialogue",
+        speaker: "母",
+        lines: [
+          "おかえり。",
+          "テレビで見ていたよ。あなたが殿堂入りしたこと。",
+          "…立派になったね。",
+        ],
+      },
+
+      // コダチ博士との会話
+      {
+        type: "dialogue",
+        speaker: "コダチ博士",
+        lines: [
+          "世界は変わり始めている。",
+          "記憶は戻らなかった。だが…見てごらん。",
+          "人々は再びモンスターに興味を持ち始めている。",
+          "恐怖ではなく、好奇心で。",
+          "新しい物語が始まっているんだ。",
+        ],
+      },
+
+      // ソウマとの最後の会話
+      {
+        type: "dialogue",
+        speaker: "ソウマ",
+        lines: [
+          "…やっと戻ったか。",
+          "俺もモンスターの研究をしてみようと思う。",
+          "お前が見せてくれたもの、ちゃんと覚えてるから。",
+          "…認めたくなかったんだ。こいつらのことが、怖くなくなってきてたことを。",
+          "ありがとな。",
+        ],
+      },
+
+      // エンディングメッセージ
+      { type: "wait", ms: 2000 },
+      {
+        type: "dialogue",
+        lines: [
+          "あなたの旅は、ここで一つの区切りを迎えます。",
+          "しかし、レムニアの物語はまだ続いています。",
+          "新しい冒険が、あなたを待っています。",
+        ],
+      },
+
+      // エンディング完了フラグ
+      { type: "set_flag", flag: "ending_complete", value: true },
+
+      // パーティ回復（ポストゲーム開始の準備）
+      { type: "heal" },
+    ],
+  };
+}
+
+/**
+ * ポストゲーム解放時のスクリプト
+ * エンディング完了後にコダマ町で表示される
+ */
+export function createPostgameIntroScript(): EventScript {
+  return {
+    id: "postgame_intro",
+    trigger: [
+      { flag: "ending_complete", value: true },
+      { flag: "postgame_started", value: false },
+    ],
+    commands: [
+      {
+        type: "dialogue",
+        speaker: "コダチ博士",
+        lines: [
+          "さて…チャンピオンになったからと言って、やるべきことがなくなったわけじゃない。",
+          "セイレイ山にオモイデの気配を感じる。会いに行ってみないか？",
+          "それに、忘却の遺跡の奥にもまだ調査していない場所がある。",
+          "レムニアの物語は、まだ終わっていないよ。",
+        ],
+      },
+      { type: "set_flag", flag: "postgame_started", value: true },
+    ],
+  };
+}
+
+/**
+ * ソウマ最終バトルスクリプト（ポストゲーム）
+ */
+export function createSoumaFinalBattleScript(): EventScript {
+  return {
+    id: "souma_final_battle",
+    trigger: [
+      { flag: "ending_complete", value: true },
+      { flag: "souma_final_beaten", value: false },
+    ],
+    commands: [
+      {
+        type: "dialogue",
+        speaker: "ソウマ",
+        lines: [
+          "…待ってたよ。",
+          "全力で来い。お前にそう言えるようになった自分が、少し誇らしい。",
+        ],
+      },
+      {
+        type: "battle",
+        trainerName: "モンスター研究者 ソウマ",
+        party: [
+          { speciesId: "oonezumi", level: 62 },
+          { speciesId: "hayatedori", level: 63 },
+          { speciesId: "dokunuma", level: 63 },
+          { speciesId: "hikarineko", level: 64 },
+          { speciesId: "kawadojou", level: 64 },
+          { speciesId: "hanamushi", level: 65 },
+        ],
+      },
+      {
+        type: "dialogue",
+        speaker: "ソウマ",
+        lines: [
+          "…やっぱりお前には勝てないか。",
+          "でも…悔しいけど、嫌な気持ちじゃない。",
+          "お前と戦えて、楽しかった。",
+          "…ありがとう。これからも、よろしくな。",
+        ],
+      },
+      { type: "set_flag", flag: "souma_final_beaten", value: true },
+    ],
+  };
+}


### PR DESCRIPTION
## Summary
- エンディングシーケンス（殿堂入り→帰還→エピローグ）
- ポストゲーム解放イベント
- ソウマ最終バトル（ポストゲーム）

## Test plan
- [x] 全405テストパス
- [x] エンディング15件のテスト

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)