### PR TITLE
feat: バトルアニメーション & 進化アニメーション (#83, #86)

### DIFF
--- a/src/components/ui/BattleAnimation.tsx
+++ b/src/components/ui/BattleAnimation.tsx
@@ -1,0 +1,377 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+/**
+ * バトルアニメーション (#83)
+ * 技エフェクト、被ダメージ、瀕死演出
+ */
+
+/** アニメーションの種類 */
+export type BattleAnimationType =
+  | "attack_physical"
+  | "attack_special"
+  | "damage"
+  | "faint"
+  | "status_inflict"
+  | "stat_up"
+  | "stat_down"
+  | "heal";
+
+/** タイプ別のエフェクト色 */
+const TYPE_COLORS: Record<string, string> = {
+  normal: "#A8A878",
+  fire: "#F08030",
+  water: "#6890F0",
+  grass: "#78C850",
+  electric: "#F8D030",
+  ice: "#98D8D8",
+  fighting: "#C03028",
+  poison: "#A040A0",
+  ground: "#E0C068",
+  flying: "#A890F0",
+  psychic: "#F85888",
+  bug: "#A8B820",
+  rock: "#B8A038",
+  ghost: "#705898",
+  dragon: "#7038F8",
+  dark: "#705848",
+  steel: "#B8B8D0",
+  fairy: "#EE99AC",
+};
+
+export interface BattleAnimationEvent {
+  type: BattleAnimationType;
+  /** 対象: "player" | "opponent" */
+  target: "player" | "opponent";
+  /** 技タイプ（エフェクト色の決定に使用） */
+  moveType?: string;
+  /** アニメーション時間（ms） */
+  duration?: number;
+}
+
+export interface BattleAnimationProps {
+  /** 再生するアニメーションイベント */
+  event: BattleAnimationEvent | null;
+  /** アニメーション完了時のコールバック */
+  onComplete: () => void;
+}
+
+/**
+ * バトルフィールド上のアニメーションオーバーレイ
+ * BattleScreen内のバトルアリーナ部分に重ねて使用
+ */
+export function BattleAnimation({ event, onComplete }: BattleAnimationProps) {
+  const [phase, setPhase] = useState<"idle" | "playing" | "done">("idle");
+  const [opacity, setOpacity] = useState(0);
+  const [scale, setScale] = useState(1);
+  const [translateX, setTranslateX] = useState(0);
+  const [translateY, setTranslateY] = useState(0);
+
+  const reset = useCallback(() => {
+    setPhase("idle");
+    setOpacity(0);
+    setScale(1);
+    setTranslateX(0);
+    setTranslateY(0);
+  }, []);
+
+  useEffect(() => {
+    if (!event) {
+      reset();
+      return;
+    }
+
+    setPhase("playing");
+    const duration = event.duration ?? getDefaultDuration(event.type);
+
+    // アニメーションのキーフレームをsetTimeoutで再現
+    const timers: ReturnType<typeof setTimeout>[] = [];
+
+    switch (event.type) {
+      case "attack_physical": {
+        // 突進アニメーション: 前に飛び出す→戻る
+        setOpacity(0);
+        const dir = event.target === "opponent" ? -1 : 1;
+        timers.push(setTimeout(() => setTranslateX(dir * 30), 0));
+        timers.push(setTimeout(() => setTranslateX(0), duration * 0.4));
+        timers.push(setTimeout(() => {
+          // ヒットフラッシュ
+          setOpacity(1);
+          setScale(1.2);
+        }, duration * 0.35));
+        timers.push(setTimeout(() => {
+          setOpacity(0);
+          setScale(1);
+        }, duration * 0.6));
+        break;
+      }
+      case "attack_special": {
+        // 特殊技: 光弾エフェクト
+        setOpacity(0);
+        setScale(0.3);
+        timers.push(setTimeout(() => {
+          setOpacity(1);
+          setScale(1.5);
+        }, duration * 0.1));
+        timers.push(setTimeout(() => {
+          setScale(2);
+          setOpacity(0);
+        }, duration * 0.6));
+        break;
+      }
+      case "damage": {
+        // 被ダメ: 点滅
+        let flashCount = 0;
+        const flashInterval = setInterval(() => {
+          flashCount++;
+          setOpacity(flashCount % 2 === 0 ? 0 : 0.6);
+          if (flashCount >= 6) {
+            clearInterval(flashInterval);
+            setOpacity(0);
+          }
+        }, duration / 7);
+        timers.push(setTimeout(() => clearInterval(flashInterval), duration));
+        break;
+      }
+      case "faint": {
+        // 瀕死: 下にスライドしながらフェードアウト
+        setOpacity(0);
+        setTranslateY(0);
+        timers.push(setTimeout(() => {
+          setOpacity(0.5);
+          setTranslateY(40);
+        }, duration * 0.2));
+        timers.push(setTimeout(() => {
+          setOpacity(0);
+          setTranslateY(80);
+        }, duration * 0.6));
+        break;
+      }
+      case "status_inflict": {
+        // 状態異常付与: パルス
+        setScale(1);
+        setOpacity(0);
+        timers.push(setTimeout(() => {
+          setOpacity(0.7);
+          setScale(1.3);
+        }, duration * 0.1));
+        timers.push(setTimeout(() => {
+          setOpacity(0.4);
+          setScale(1);
+        }, duration * 0.4));
+        timers.push(setTimeout(() => {
+          setOpacity(0);
+        }, duration * 0.7));
+        break;
+      }
+      case "stat_up": {
+        // ステータスアップ: 上に矢印フロート
+        setOpacity(0);
+        setTranslateY(20);
+        timers.push(setTimeout(() => {
+          setOpacity(1);
+          setTranslateY(-20);
+        }, duration * 0.1));
+        timers.push(setTimeout(() => {
+          setOpacity(0);
+          setTranslateY(-40);
+        }, duration * 0.6));
+        break;
+      }
+      case "stat_down": {
+        // ステータスダウン: 下に矢印フロート
+        setOpacity(0);
+        setTranslateY(-20);
+        timers.push(setTimeout(() => {
+          setOpacity(1);
+          setTranslateY(20);
+        }, duration * 0.1));
+        timers.push(setTimeout(() => {
+          setOpacity(0);
+          setTranslateY(40);
+        }, duration * 0.6));
+        break;
+      }
+      case "heal": {
+        // 回復: 緑のきらめき
+        setOpacity(0);
+        setScale(0.5);
+        timers.push(setTimeout(() => {
+          setOpacity(0.8);
+          setScale(1.2);
+        }, duration * 0.15));
+        timers.push(setTimeout(() => {
+          setOpacity(0.4);
+          setScale(1.5);
+        }, duration * 0.5));
+        timers.push(setTimeout(() => {
+          setOpacity(0);
+        }, duration * 0.8));
+        break;
+      }
+    }
+
+    // 完了通知
+    timers.push(setTimeout(() => {
+      reset();
+      setPhase("done");
+      onComplete();
+    }, duration));
+
+    return () => {
+      timers.forEach(clearTimeout);
+    };
+  }, [event, onComplete, reset]);
+
+  if (!event || phase === "idle") return null;
+
+  const color = getEffectColor(event);
+  const isTargetLeft = event.target === "opponent";
+
+  return (
+    <div
+      className="pointer-events-none absolute inset-0"
+      aria-hidden="true"
+    >
+      {/* メインエフェクト */}
+      <div
+        className="absolute"
+        style={{
+          left: isTargetLeft ? "25%" : "65%",
+          top: "40%",
+          transform: `translate(-50%, -50%) translateX(${translateX}px) translateY(${translateY}px) scale(${scale})`,
+          opacity,
+          transition: "all 150ms ease-out",
+        }}
+      >
+        <div
+          className="h-16 w-16 rounded-full"
+          style={{
+            background: `radial-gradient(circle, ${color}80, ${color}20, transparent)`,
+            boxShadow: `0 0 20px ${color}60`,
+          }}
+        />
+      </div>
+
+      {/* 追加のパーティクル（ダメージ時のフラッシュ） */}
+      {event.type === "damage" && (
+        <div
+          className="absolute inset-0"
+          style={{
+            backgroundColor: "#ffffff",
+            opacity: opacity * 0.3,
+            transition: "opacity 80ms ease-out",
+          }}
+        />
+      )}
+
+      {/* 瀕死の暗転 */}
+      {event.type === "faint" && (
+        <div
+          className="absolute inset-0"
+          style={{
+            backgroundColor: "#000000",
+            opacity: opacity * 0.4,
+            transition: "opacity 300ms ease-out",
+          }}
+        />
+      )}
+
+      {/* ステータスアップ/ダウンの矢印テキスト */}
+      {(event.type === "stat_up" || event.type === "stat_down") && (
+        <div
+          className="absolute font-mono text-2xl font-bold"
+          style={{
+            left: isTargetLeft ? "25%" : "65%",
+            top: "35%",
+            transform: `translate(-50%, -50%) translateY(${translateY}px)`,
+            opacity,
+            color,
+            transition: "all 150ms ease-out",
+            textShadow: `0 0 8px ${color}`,
+          }}
+        >
+          {event.type === "stat_up" ? "▲" : "▼"}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function getDefaultDuration(type: BattleAnimationType): number {
+  switch (type) {
+    case "attack_physical":
+    case "attack_special":
+      return 600;
+    case "damage":
+      return 500;
+    case "faint":
+      return 800;
+    case "status_inflict":
+      return 500;
+    case "stat_up":
+    case "stat_down":
+      return 500;
+    case "heal":
+      return 600;
+  }
+}
+
+function getEffectColor(event: BattleAnimationEvent): string {
+  if (event.type === "heal") return "#78C850"; // 緑
+  if (event.type === "stat_up") return "#F8D030"; // 黄
+  if (event.type === "stat_down") return "#6890F0"; // 青
+  if (event.type === "damage" || event.type === "faint") return "#ffffff";
+  if (event.moveType && TYPE_COLORS[event.moveType]) {
+    return TYPE_COLORS[event.moveType];
+  }
+  return "#ffffff";
+}
+
+/**
+ * バトルアニメーションイベントを生成するヘルパー
+ */
+export function createAttackAnimation(
+  target: "player" | "opponent",
+  category: "physical" | "special",
+  moveType: string,
+): BattleAnimationEvent {
+  return {
+    type: category === "physical" ? "attack_physical" : "attack_special",
+    target,
+    moveType,
+  };
+}
+
+export function createDamageAnimation(
+  target: "player" | "opponent",
+): BattleAnimationEvent {
+  return { type: "damage", target };
+}
+
+export function createFaintAnimation(
+  target: "player" | "opponent",
+): BattleAnimationEvent {
+  return { type: "faint", target, duration: 1000 };
+}
+
+export function createStatusAnimation(
+  target: "player" | "opponent",
+  moveType?: string,
+): BattleAnimationEvent {
+  return { type: "status_inflict", target, moveType };
+}
+
+export function createStatChangeAnimation(
+  target: "player" | "opponent",
+  direction: "up" | "down",
+): BattleAnimationEvent {
+  return { type: direction === "up" ? "stat_up" : "stat_down", target };
+}
+
+export function createHealAnimation(
+  target: "player" | "opponent",
+): BattleAnimationEvent {
+  return { type: "heal", target };
+}

--- a/src/components/ui/EvolutionAnimation.tsx
+++ b/src/components/ui/EvolutionAnimation.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+/**
+ * 進化アニメーション (#86)
+ * モンスター進化時の演出: 光る→シルエット切り替え→新モンスター登場
+ */
+
+export type EvolutionPhase =
+  | "idle"
+  | "start"        // おめでとう！テキスト表示
+  | "glow"         // 白く光り始める
+  | "flash"        // 画面全体フラッシュ
+  | "transform"    // シルエット変化
+  | "reveal"       // 新モンスター登場
+  | "complete";    // 完了
+
+export interface EvolutionAnimationProps {
+  /** 進化前のモンスター名 */
+  fromName: string;
+  /** 進化後のモンスター名 */
+  toName: string;
+  /** アニメーション開始フラグ */
+  isPlaying: boolean;
+  /** 完了時コールバック */
+  onComplete: () => void;
+  /** キャンセル（B連打）可能か */
+  cancellable?: boolean;
+  /** キャンセル時コールバック */
+  onCancel?: () => void;
+}
+
+/** 各フェーズの時間（ms） */
+const PHASE_DURATIONS: Record<EvolutionPhase, number> = {
+  idle: 0,
+  start: 2000,
+  glow: 2000,
+  flash: 600,
+  transform: 1500,
+  reveal: 2000,
+  complete: 0,
+};
+
+export function EvolutionAnimation({
+  fromName,
+  toName,
+  isPlaying,
+  onComplete,
+  cancellable = true,
+  onCancel,
+}: EvolutionAnimationProps) {
+  const [phase, setPhase] = useState<EvolutionPhase>("idle");
+  const [glowIntensity, setGlowIntensity] = useState(0);
+  const [flashOpacity, setFlashOpacity] = useState(0);
+  const [silhouetteScale, setSilhouetteScale] = useState(1);
+  const [cancelPressCount, setCancelPressCount] = useState(0);
+
+  // フェーズ遷移
+  useEffect(() => {
+    if (!isPlaying) {
+      setPhase("idle");
+      setGlowIntensity(0);
+      setFlashOpacity(0);
+      setSilhouetteScale(1);
+      setCancelPressCount(0);
+      return;
+    }
+
+    if (phase === "idle") {
+      setPhase("start");
+    }
+  }, [isPlaying, phase]);
+
+  // 各フェーズのアニメーション
+  useEffect(() => {
+    if (phase === "idle" || phase === "complete") return;
+
+    const duration = PHASE_DURATIONS[phase];
+    const timers: ReturnType<typeof setTimeout>[] = [];
+
+    switch (phase) {
+      case "start":
+        // テキスト表示後に次フェーズ
+        timers.push(setTimeout(() => setPhase("glow"), duration));
+        break;
+
+      case "glow": {
+        // 徐々に白く光る（パルス効果）
+        let glowStep = 0;
+        const glowInterval = setInterval(() => {
+          glowStep++;
+          // サイン波でパルス + 徐々に強くなる
+          const base = glowStep / 20;
+          const pulse = Math.sin(glowStep * 0.5) * 0.15;
+          setGlowIntensity(Math.min(1, base + pulse));
+        }, 100);
+        timers.push(setTimeout(() => {
+          clearInterval(glowInterval);
+          setGlowIntensity(1);
+          setPhase("flash");
+        }, duration));
+        break;
+      }
+
+      case "flash":
+        // 全画面フラッシュ
+        setFlashOpacity(1);
+        timers.push(setTimeout(() => {
+          setFlashOpacity(0);
+          setPhase("transform");
+        }, duration));
+        break;
+
+      case "transform": {
+        // シルエット変化アニメーション
+        setSilhouetteScale(1.3);
+        timers.push(setTimeout(() => {
+          setSilhouetteScale(0.8);
+        }, duration * 0.3));
+        timers.push(setTimeout(() => {
+          setSilhouetteScale(1);
+          setGlowIntensity(0);
+          setPhase("reveal");
+        }, duration));
+        break;
+      }
+
+      case "reveal":
+        // 新モンスター登場テキスト
+        timers.push(setTimeout(() => {
+          setPhase("complete");
+          onComplete();
+        }, duration));
+        break;
+    }
+
+    return () => {
+      timers.forEach(clearTimeout);
+    };
+  }, [phase, onComplete]);
+
+  // Bボタン連打でキャンセル
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!cancellable || !onCancel) return;
+      if (phase !== "glow" && phase !== "start") return;
+
+      if (e.key === "Escape" || e.key === "x") {
+        setCancelPressCount((prev) => {
+          const next = prev + 1;
+          if (next >= 3) {
+            onCancel();
+            return 0;
+          }
+          return next;
+        });
+      }
+
+      // 進行キー
+      if (e.key === "Enter" || e.key === "z" || e.key === " ") {
+        // 何もしない（進化は自動進行）
+      }
+    },
+    [cancellable, onCancel, phase],
+  );
+
+  if (!isPlaying && phase === "idle") return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-black"
+      onKeyDown={handleKeyDown}
+      tabIndex={0}
+      role="dialog"
+      aria-label="進化アニメーション"
+    >
+      {/* 背景のグラデーション */}
+      <div
+        className="absolute inset-0"
+        style={{
+          background: `radial-gradient(circle at center, rgba(100, 149, 237, ${glowIntensity * 0.3}), transparent 70%)`,
+          transition: "all 200ms ease-out",
+        }}
+      />
+
+      {/* 全画面フラッシュ */}
+      <div
+        className="absolute inset-0 bg-white"
+        style={{
+          opacity: flashOpacity,
+          transition: "opacity 200ms ease-out",
+        }}
+      />
+
+      {/* テキスト: "おや？" */}
+      {phase === "start" && (
+        <div className="absolute top-8 w-full text-center">
+          <p className="font-mono text-2xl text-white">おや…？</p>
+          <p className="mt-2 font-mono text-xl text-gray-300">
+            {fromName}のようすが…！
+          </p>
+        </div>
+      )}
+
+      {/* モンスターシルエット */}
+      <div
+        className="relative flex items-center justify-center"
+        style={{
+          transform: `scale(${silhouetteScale})`,
+          transition: "transform 300ms ease-out",
+        }}
+      >
+        {/* 光のオーラ */}
+        <div
+          className="absolute h-40 w-40 rounded-full"
+          style={{
+            background: `radial-gradient(circle, rgba(255, 255, 255, ${glowIntensity * 0.8}), rgba(200, 200, 255, ${glowIntensity * 0.3}), transparent)`,
+            filter: `blur(${10 + glowIntensity * 20}px)`,
+            transition: "all 200ms ease-out",
+          }}
+        />
+
+        {/* モンスターアイコン（プレースホルダー） */}
+        <div
+          className="relative flex h-24 w-24 items-center justify-center rounded-full text-5xl"
+          style={{
+            backgroundColor: `rgba(255, 255, 255, ${glowIntensity * 0.3 + 0.1})`,
+            boxShadow: `0 0 ${20 + glowIntensity * 40}px rgba(255, 255, 255, ${glowIntensity * 0.5})`,
+            transition: "all 200ms ease-out",
+          }}
+        >
+          {phase === "reveal" || phase === "complete" ? "✨" : "🔮"}
+        </div>
+      </div>
+
+      {/* テキスト: 進化完了 */}
+      {phase === "reveal" && (
+        <div className="absolute bottom-16 w-full text-center">
+          <p className="font-mono text-lg text-gray-300">
+            おめでとう！ {fromName}は
+          </p>
+          <p className="mt-1 font-mono text-2xl font-bold text-white">
+            {toName}に　しんかした！
+          </p>
+        </div>
+      )}
+
+      {/* キャンセルヒント */}
+      {cancellable && (phase === "start" || phase === "glow") && (
+        <div className="absolute bottom-4 w-full text-center">
+          <p className="font-mono text-xs text-gray-600">
+            Bボタン(X)を3回押すと進化をキャンセル
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/__tests__/battle-animation.test.ts
+++ b/src/components/ui/__tests__/battle-animation.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import {
+  createAttackAnimation,
+  createDamageAnimation,
+  createFaintAnimation,
+  createStatusAnimation,
+  createStatChangeAnimation,
+  createHealAnimation,
+} from "../BattleAnimation";
+
+describe("バトルアニメーションイベント生成", () => {
+  describe("createAttackAnimation", () => {
+    it("物理技の攻撃アニメーションを生成する", () => {
+      const event = createAttackAnimation("opponent", "physical", "fire");
+      expect(event.type).toBe("attack_physical");
+      expect(event.target).toBe("opponent");
+      expect(event.moveType).toBe("fire");
+    });
+
+    it("特殊技の攻撃アニメーションを生成する", () => {
+      const event = createAttackAnimation("player", "special", "water");
+      expect(event.type).toBe("attack_special");
+      expect(event.target).toBe("player");
+      expect(event.moveType).toBe("water");
+    });
+  });
+
+  describe("createDamageAnimation", () => {
+    it("プレイヤーへのダメージアニメーション", () => {
+      const event = createDamageAnimation("player");
+      expect(event.type).toBe("damage");
+      expect(event.target).toBe("player");
+    });
+
+    it("相手へのダメージアニメーション", () => {
+      const event = createDamageAnimation("opponent");
+      expect(event.type).toBe("damage");
+      expect(event.target).toBe("opponent");
+    });
+  });
+
+  describe("createFaintAnimation", () => {
+    it("瀕死アニメーションは長めの持続時間", () => {
+      const event = createFaintAnimation("player");
+      expect(event.type).toBe("faint");
+      expect(event.target).toBe("player");
+      expect(event.duration).toBe(1000);
+    });
+  });
+
+  describe("createStatusAnimation", () => {
+    it("状態異常アニメーションを生成する", () => {
+      const event = createStatusAnimation("opponent", "poison");
+      expect(event.type).toBe("status_inflict");
+      expect(event.target).toBe("opponent");
+      expect(event.moveType).toBe("poison");
+    });
+
+    it("moveType無しでも生成可能", () => {
+      const event = createStatusAnimation("player");
+      expect(event.type).toBe("status_inflict");
+      expect(event.moveType).toBeUndefined();
+    });
+  });
+
+  describe("createStatChangeAnimation", () => {
+    it("ステータスアップアニメーション", () => {
+      const event = createStatChangeAnimation("player", "up");
+      expect(event.type).toBe("stat_up");
+      expect(event.target).toBe("player");
+    });
+
+    it("ステータスダウンアニメーション", () => {
+      const event = createStatChangeAnimation("opponent", "down");
+      expect(event.type).toBe("stat_down");
+      expect(event.target).toBe("opponent");
+    });
+  });
+
+  describe("createHealAnimation", () => {
+    it("回復アニメーションを生成する", () => {
+      const event = createHealAnimation("player");
+      expect(event.type).toBe("heal");
+      expect(event.target).toBe("player");
+    });
+  });
+
+  describe("全アニメーションタイプの網羅", () => {
+    it("8種類のアニメーションタイプが全て生成可能", () => {
+      const types = new Set([
+        createAttackAnimation("player", "physical", "normal").type,
+        createAttackAnimation("player", "special", "fire").type,
+        createDamageAnimation("player").type,
+        createFaintAnimation("player").type,
+        createStatusAnimation("player").type,
+        createStatChangeAnimation("player", "up").type,
+        createStatChangeAnimation("player", "down").type,
+        createHealAnimation("player").type,
+      ]);
+      expect(types.size).toBe(8);
+    });
+
+    it("全タイプでtargetがplayer/opponentのどちらかを指定可能", () => {
+      const targets = ["player", "opponent"] as const;
+      for (const target of targets) {
+        expect(createAttackAnimation(target, "physical", "normal").target).toBe(target);
+        expect(createDamageAnimation(target).target).toBe(target);
+        expect(createFaintAnimation(target).target).toBe(target);
+        expect(createHealAnimation(target).target).toBe(target);
+      }
+    });
+  });
+});

--- a/src/components/ui/__tests__/evolution-animation.test.ts
+++ b/src/components/ui/__tests__/evolution-animation.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import type { EvolutionPhase } from "../EvolutionAnimation";
+
+/**
+ * 進化アニメーションのフェーズ遷移ロジックのテスト
+ * UIレンダリングはReact Testing Libraryが必要だが、
+ * ここではフェーズ遷移の設計が正しいことを検証する
+ */
+
+/** フェーズの正しい遷移順序 */
+const EXPECTED_PHASE_ORDER: EvolutionPhase[] = [
+  "idle",
+  "start",
+  "glow",
+  "flash",
+  "transform",
+  "reveal",
+  "complete",
+];
+
+/** 各フェーズの期待時間（ms） */
+const PHASE_DURATIONS: Record<EvolutionPhase, number> = {
+  idle: 0,
+  start: 2000,
+  glow: 2000,
+  flash: 600,
+  transform: 1500,
+  reveal: 2000,
+  complete: 0,
+};
+
+describe("進化アニメーション設計", () => {
+  it("フェーズは7段階", () => {
+    expect(EXPECTED_PHASE_ORDER).toHaveLength(7);
+  });
+
+  it("フェーズがidleから始まりcompleteで終わる", () => {
+    expect(EXPECTED_PHASE_ORDER[0]).toBe("idle");
+    expect(EXPECTED_PHASE_ORDER[EXPECTED_PHASE_ORDER.length - 1]).toBe("complete");
+  });
+
+  it("演出の合計時間が6秒以上（idleとcomplete除く）", () => {
+    const totalDuration = EXPECTED_PHASE_ORDER.reduce(
+      (sum, phase) => sum + PHASE_DURATIONS[phase],
+      0,
+    );
+    expect(totalDuration).toBeGreaterThanOrEqual(6000);
+  });
+
+  it("各フェーズのDurationが非負", () => {
+    for (const phase of EXPECTED_PHASE_ORDER) {
+      expect(PHASE_DURATIONS[phase]).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("flashフェーズは短い（1秒未満）", () => {
+    expect(PHASE_DURATIONS.flash).toBeLessThan(1000);
+  });
+
+  it("glowフェーズは十分な長さ（光の演出のため1.5秒以上）", () => {
+    expect(PHASE_DURATIONS.glow).toBeGreaterThanOrEqual(1500);
+  });
+
+  it("revealフェーズは十分な長さ（テキスト読み取りのため1.5秒以上）", () => {
+    expect(PHASE_DURATIONS.reveal).toBeGreaterThanOrEqual(1500);
+  });
+
+  it("キャンセル可能なフェーズはstartとglowのみ", () => {
+    const cancellablePhases: EvolutionPhase[] = ["start", "glow"];
+    // flashに入ったらキャンセル不可（デザイン意図の確認）
+    expect(cancellablePhases).not.toContain("flash");
+    expect(cancellablePhases).not.toContain("transform");
+    expect(cancellablePhases).not.toContain("reveal");
+  });
+});


### PR DESCRIPTION
## Summary
- バトル中の技エフェクト、被ダメージ、瀕死演出を実装するBattleAnimationコンポーネントを追加
- モンスター進化時のアニメーション演出を実装するEvolutionAnimationコンポーネントを追加

### BattleAnimation
- 8種類のアニメーション: `attack_physical`, `attack_special`, `damage`, `faint`, `status_inflict`, `stat_up`, `stat_down`, `heal`
- 全18タイプのエフェクト色マッピング
- ヘルパー関数API: `createAttackAnimation()`, `createDamageAnimation()` 等

### EvolutionAnimation
- 7段階フェーズ: idle→start→glow→flash→transform→reveal→complete
- グロウ＆フラッシュエフェクト、シルエット変化
- Bボタンキャンセル（start/glowフェーズのみ、3回連打）

## Test plan
- [x] `bun run type-check` — 型エラーなし
- [x] `bun run test` — 全435テストパス（20テスト新規追加）
- [x] 全8種バトルアニメーションタイプの生成テスト
- [x] 進化アニメーションのフェーズ設計テスト

Closes #83
Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)