### PR TITLE
fix: 完全プレイ可能化のための残存バグ4件を修正

### DIFF
--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -1,11 +1,48 @@
 "use client";
 
+import { useState, useCallback, useMemo, useRef } from "react";
 import { useGameState, useGameDispatch } from "./GameProvider";
 import { TitleScreen } from "./screens/TitleScreen";
 import { StarterSelect, type StarterOption } from "./screens/StarterSelect";
+import { OverworldScreen } from "./screens/OverworldScreen";
+import { BattleScreen, type BattleAction as BattleScreenAction } from "./screens/BattleScreen";
+import { MenuScreen } from "./screens/MenuScreen";
+import { PartyScreen, type PartyMemberInfo } from "./screens/PartyScreen";
+import { BagScreen, type BagItemInfo } from "./screens/BagScreen";
+import { PokedexScreen, type PokedexEntry } from "./screens/PokedexScreen";
+import { MessageWindow } from "./ui/MessageWindow";
 import type { MonsterInstance } from "@/types";
+import { BattleEngine } from "@/engine/battle/engine";
+import type { BattleAction } from "@/engine/battle/state-machine";
+import { processEncounter, generateWildMonster } from "@/engine/map/encounter";
+import { useHealingCenter as healAtCenter } from "@/engine/map/healing";
+import { calcAllStats } from "@/engine/monster/stats";
+import { getLearnableMoves, learnMove, replaceMove } from "@/engine/monster/moves";
+import { swapPartyOrder } from "@/engine/monster/party";
+import { addItem, removeItem, useHealItem as applyHealItem } from "@/engine/item/bag";
+import { executeCaptureFlow } from "@/engine/capture/capture-flow";
+import { ALL_SPECIES, getSpeciesById } from "@/data/monsters";
+import { saveGame, loadGame } from "@/engine/state/save-data";
+import { checkFlagRequirement } from "@/engine/state/story-flags";
+import {
+  createSpeciesResolver,
+  createMoveResolver,
+  createItemResolver,
+  createMapResolver,
+} from "@/engine/resolvers";
+import { resolveCommands, type EventOutput } from "@/engine/event/event-script";
+import { createGymBattleScript, canChallengeGym } from "@/engine/event/gym";
+import { GYM_LEADERS } from "@/data/gyms/gym-leaders";
+import { OBLIVION_EVENTS } from "@/engine/event/oblivion-events";
+import {
+  ELITE_FOUR,
+  CHAMPION,
+  createEliteFourScript,
+  createChampionScript,
+} from "@/engine/event/elite-four";
+import { createEndingScript } from "@/engine/event/ending";
 
-/** スターター定義（実際のモンスターデータと一致） */
+/** スターター定義 */
 const STARTERS: StarterOption[] = [
   {
     speciesId: "himori",
@@ -28,28 +65,1005 @@ const STARTERS: StarterOption[] = [
 ];
 
 function createStarterInstance(speciesId: string): MonsterInstance {
+  const species = getSpeciesById(speciesId)!;
+  const ivs = { hp: 20, atk: 20, def: 20, spAtk: 20, spDef: 20, speed: 20 };
+  const evs = { hp: 0, atk: 0, def: 0, spAtk: 0, spDef: 0, speed: 0 };
+  const maxHp = calcAllStats(species.baseStats, ivs, evs, 5, "hardy").hp;
   return {
     uid: crypto.randomUUID(),
     speciesId,
     level: 5,
     exp: 0,
     nature: "hardy",
-    ivs: { hp: 20, atk: 20, def: 20, spAtk: 20, spDef: 20, speed: 20 },
-    evs: { hp: 0, atk: 0, def: 0, spAtk: 0, spDef: 0, speed: 0 },
-    currentHp: 20,
-    moves: [{ moveId: "tackle", currentPp: 35 }],
+    ivs,
+    evs,
+    currentHp: maxHp,
+    moves: species.learnset
+      .filter((e) => e.level <= 5)
+      .slice(-4)
+      .map((e) => {
+        const moveDef = moveResolver(e.moveId);
+        return { moveId: e.moveId, currentPp: moveDef.pp };
+      }),
     status: null,
   };
 }
+
+// Resolvers（モジュールスコープで一度だけ生成）
+const speciesResolver = createSpeciesResolver();
+const moveResolver = createMoveResolver();
+const itemResolver = createItemResolver();
+const mapResolver = createMapResolver();
+
+/** maxHp計算ヘルパー */
+function getMaxHp(monster: MonsterInstance): number {
+  const species = speciesResolver(monster.speciesId);
+  return calcAllStats(species.baseStats, monster.ivs, monster.evs, monster.level, monster.nature)
+    .hp;
+}
+
+/** 前の画面を記録するためのタイプ */
+type OverlayScreen = "menu" | "party" | "bag" | "pokedex" | null;
 
 export function Game() {
   const state = useGameState();
   const dispatch = useGameDispatch();
 
+  // --- バトル状態 ---
+  const [battleEngine, setBattleEngine] = useState<BattleEngine | null>(null);
+  const [battleMessages, setBattleMessages] = useState<string[]>([]);
+  const [isBattleProcessing, setIsBattleProcessing] = useState(false);
+  const [wildMonster, setWildMonster] = useState<MonsterInstance | null>(null);
+
+  // --- オーバーレイ画面（メニュー系） ---
+  const [overlayScreen, setOverlayScreen] = useState<OverlayScreen>(null);
+  const [, setReturnScreen] = useState<"overworld" | "battle">("overworld");
+
+  // --- メッセージウィンドウ ---
+  const [pendingMessages, setPendingMessages] = useState<string[] | null>(null);
+  const [messageCallback, setMessageCallback] = useState<(() => void) | null>(null);
+
+  // --- 技習得UI ---
+  const [learnMoveState, setLearnMoveState] = useState<{
+    monster: MonsterInstance;
+    moveId: string;
+    moveName: string;
+  } | null>(null);
+
+  // バトル中のバッグ選択用
+  const [battleBagMode, setBattleBagMode] = useState(false);
+  const [battlePartyMode, setBattlePartyMode] = useState(false);
+
+  // --- イベントスクリプトキュー ---
+  const eventQueueRef = useRef<EventOutput[]>([]);
+  const isEventRunningRef = useRef(false);
+  const [isTrainerBattle, setIsTrainerBattle] = useState(false);
+  const [trainerBattleName, setTrainerBattleName] = useState<string | null>(null);
+
+  // ジムリーダーNPC ID → GymDefinition マッピング
+  const gymLeaderNpcMap = useMemo(() => {
+    const map: Record<string, (typeof GYM_LEADERS)[number]> = {};
+    // NPC IDパターン: npc-gym{N}-leader → GYM_LEADERS[N-1]
+    for (const gym of GYM_LEADERS) {
+      map[`npc-gym${gym.gymNumber}-leader`] = gym;
+    }
+    return map;
+  }, []);
+
+  // 四天王・チャンピオンNPC ID マッピング
+  const leagueNpcMap = useMemo(() => {
+    const map: Record<string, { type: "elite"; index: number } | { type: "champion" }> = {};
+    for (let i = 0; i < ELITE_FOUR.length; i++) {
+      map[`npc-league-elite${i + 1}`] = { type: "elite", index: i };
+    }
+    map["npc-league-champion"] = { type: "champion" };
+    return map;
+  }, []);
+
+  /** メッセージを表示してコールバックを待つ */
+  const showMessages = useCallback((msgs: string[], callback?: () => void) => {
+    setPendingMessages(msgs);
+    setMessageCallback(() => callback ?? null);
+  }, []);
+
+  /**
+   * イベントキューから次のイベントを処理する
+   * dialogue → メッセージ表示、battle → トレーナーバトル開始、
+   * heal → パーティ回復、give_item → アイテム付与、set_flag → フラグ設定、
+   * move_player → マップ遷移、wait → 遅延
+   */
+  const processNextEvent = useCallback(() => {
+    const queue = eventQueueRef.current;
+    if (queue.length === 0) {
+      isEventRunningRef.current = false;
+      return;
+    }
+
+    const event = queue.shift()!;
+
+    switch (event.type) {
+      case "dialogue": {
+        const lines = event.speaker
+          ? event.lines.map((l) => `${event.speaker}「${l}」`)
+          : event.lines;
+        showMessages(lines, () => processNextEvent());
+        break;
+      }
+      case "set_flag":
+        dispatch({ type: "SET_STORY_FLAG", flag: event.flag, value: event.value });
+        // バッジ追加（gymN_clearedフラグの場合）
+        if (event.flag.startsWith("gym") && event.flag.endsWith("_cleared") && event.value) {
+          const gymNum = parseInt(event.flag.replace("gym", "").replace("_cleared", ""));
+          const gym = GYM_LEADERS.find((g) => g.gymNumber === gymNum);
+          if (gym && state.player) {
+            const newBadges = [...state.player.badges, gym.badgeName];
+            dispatch({ type: "UPDATE_PLAYER", updates: { badges: newBadges } });
+          }
+        }
+        processNextEvent();
+        break;
+      case "heal":
+        if (state.player) {
+          for (const monster of state.player.partyState.party) {
+            monster.currentHp = getMaxHp(monster);
+            monster.status = null;
+            for (const move of monster.moves) {
+              const moveDef = moveResolver(move.moveId);
+              move.currentPp = moveDef.pp;
+            }
+          }
+          dispatch({
+            type: "UPDATE_PLAYER",
+            updates: { partyState: { ...state.player.partyState } },
+          });
+        }
+        processNextEvent();
+        break;
+      case "give_item":
+        if (state.player) {
+          const item = itemResolver(event.itemId);
+          addItem(state.player.bag, event.itemId, event.quantity);
+          dispatch({
+            type: "UPDATE_PLAYER",
+            updates: { bag: { ...state.player.bag } },
+          });
+          showMessages([`${item.name}を${event.quantity}個手に入れた！`], () => processNextEvent());
+        }
+        break;
+      case "battle": {
+        if (!state.player) break;
+        // トレーナーバトル開始: パーティを生成してBattleEngineを起動
+        const trainerParty: MonsterInstance[] = event.party.map((p) => {
+          const entry = {
+            speciesId: p.speciesId,
+            minLevel: p.level,
+            maxLevel: p.level,
+            weight: 100,
+          };
+          return generateWildMonster(entry, speciesResolver, moveResolver);
+        });
+
+        setIsTrainerBattle(true);
+        setTrainerBattleName(event.trainerName);
+        setBattleMessages([`${event.trainerName}が勝負を仕掛けてきた！`]);
+        setIsBattleProcessing(true);
+
+        const engine = new BattleEngine(
+          state.player.partyState.party,
+          trainerParty,
+          "trainer",
+          speciesResolver,
+          moveResolver,
+        );
+        setBattleEngine(engine);
+        dispatch({ type: "CHANGE_SCREEN", screen: "battle" });
+        setTimeout(() => setIsBattleProcessing(false), 1500);
+        break;
+      }
+      case "move_player":
+        dispatch({
+          type: "SET_OVERWORLD",
+          overworld: {
+            currentMapId: event.mapId,
+            playerX: event.x,
+            playerY: event.y,
+            direction: "down",
+          },
+        });
+        dispatch({ type: "CHANGE_SCREEN", screen: "overworld" });
+        processNextEvent();
+        break;
+      case "wait":
+        setTimeout(() => processNextEvent(), event.ms);
+        break;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.player, state.storyFlags, dispatch, showMessages]);
+
+  /**
+   * イベントスクリプトを開始する
+   * コマンド列をresolveしてキューに入れ、順次処理する
+   */
+  const runEventScript = useCallback(
+    (commands: EventOutput[]) => {
+      isEventRunningRef.current = true;
+      eventQueueRef.current = [...commands];
+      processNextEvent();
+    },
+    [processNextEvent],
+  );
+
+  /** メッセージ完了ハンドラ */
+  const handleMessageComplete = useCallback(() => {
+    setPendingMessages(null);
+    const cb = messageCallback;
+    setMessageCallback(null);
+    cb?.();
+  }, [messageCallback]);
+
+  // ==========================
+  // オーバーワールド関連
+  // ==========================
+
+  const currentMap = useMemo(() => {
+    if (!state.overworld) return null;
+    try {
+      return mapResolver(state.overworld.currentMapId);
+    } catch {
+      return null;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.overworld?.currentMapId]);
+
+  /** マップ遷移処理 */
+  const handleMapTransition = useCallback(
+    (targetMapId: string, targetX: number, targetY: number) => {
+      if (isEventRunningRef.current) return;
+
+      dispatch({
+        type: "SET_OVERWORLD",
+        overworld: {
+          currentMapId: targetMapId,
+          playerX: targetX,
+          playerY: targetY,
+          direction: "down",
+        },
+      });
+
+      // マップ遷移時にストーリーイベントをチェック
+      if (state.player) {
+        // オブリヴィオン団イベント
+        for (const event of OBLIVION_EVENTS) {
+          if (event.trigger && checkFlagRequirement(state.storyFlags, event.trigger)) {
+            // このイベントがまだ未処理かチェック（最初のbranch条件で判定）
+            const outputs = resolveCommands(event.commands, state.storyFlags);
+            if (outputs.length > 0) {
+              // 少し遅延してから表示（マップ遷移後）
+              setTimeout(() => runEventScript(outputs), 500);
+              break; // 一度に1つのイベントのみ
+            }
+          }
+        }
+
+        // チャンピオン撃破後のエンディング
+        if (state.storyFlags["champion_defeated"] && !state.storyFlags["ending_complete"]) {
+          const endingScript = createEndingScript(state.player.name);
+          const outputs = resolveCommands(endingScript.commands, state.storyFlags);
+          setTimeout(() => runEventScript(outputs), 500);
+        }
+
+        // オートセーブ
+        try {
+          saveGame(
+            {
+              ...state,
+              overworld: {
+                currentMapId: targetMapId,
+                playerX: targetX,
+                playerY: targetY,
+                direction: "down",
+              },
+            },
+            1,
+          );
+        } catch {
+          // セーブ失敗は無視
+        }
+      }
+    },
+    [dispatch, state, runEventScript],
+  );
+
+  /** NPC会話処理 */
+  const handleNpcInteract = useCallback(
+    (npcId: string) => {
+      if (isEventRunningRef.current) return;
+      if (!currentMap || !state.player) return;
+
+      const npc = currentMap.npcs.find((n) => n.id === npcId);
+      if (!npc) return;
+
+      // --- ジムリーダーNPC ---
+      const gymDef = gymLeaderNpcMap[npcId];
+      if (gymDef) {
+        // 挑戦可能かチェック
+        if (!canChallengeGym(gymDef.gymNumber, state.storyFlags)) {
+          showMessages([`まだここに挑むには早いようだ。バッジが${gymDef.gymNumber - 1}個必要だ。`]);
+          return;
+        }
+        const script = createGymBattleScript(gymDef);
+        const outputs = resolveCommands(script.commands, state.storyFlags);
+        runEventScript(outputs);
+        return;
+      }
+
+      // --- 四天王・チャンピオンNPC ---
+      const leagueEntry = leagueNpcMap[npcId];
+      if (leagueEntry) {
+        let script;
+        if (leagueEntry.type === "elite") {
+          // 前の四天王をクリアしているか
+          if (leagueEntry.index > 0) {
+            const prevFlag = `elite_four_${leagueEntry.index}_cleared`;
+            if (!state.storyFlags[prevFlag]) {
+              showMessages(["まだ先に進めないようだ。"]);
+              return;
+            }
+          }
+          script = createEliteFourScript(ELITE_FOUR[leagueEntry.index], leagueEntry.index);
+        } else {
+          // チャンピオン: 全四天王クリアが必要
+          const allEliteCleared = ELITE_FOUR.every(
+            (_, i) => state.storyFlags[`elite_four_${i + 1}_cleared`],
+          );
+          if (!allEliteCleared) {
+            showMessages(["まだ四天王を全員倒していない。"]);
+            return;
+          }
+          script = createChampionScript(CHAMPION);
+        }
+        const outputs = resolveCommands(script.commands, state.storyFlags);
+        runEventScript(outputs);
+        return;
+      }
+
+      // 条件付きダイアログ
+      let dialogue = npc.dialogue;
+      if (npc.conditionalDialogues) {
+        for (const cd of npc.conditionalDialogues) {
+          if (checkFlagRequirement(state.storyFlags, cd.condition)) {
+            dialogue = cd.dialogue;
+            break;
+          }
+        }
+      }
+
+      // 回復イベント
+      if (npc.onInteract?.heal) {
+        const result = healAtCenter(state.player.partyState.party, getMaxHp, moveResolver);
+        showMessages([...dialogue, result.message]);
+        dispatch({
+          type: "UPDATE_PLAYER",
+          updates: {
+            partyState: { ...state.player.partyState },
+          },
+        });
+        return;
+      }
+
+      // アイテム付与イベント
+      if (npc.onInteract?.giveItem) {
+        const { itemId, quantity } = npc.onInteract.giveItem;
+        const item = itemResolver(itemId);
+        addItem(state.player.bag, itemId, quantity);
+        dispatch({
+          type: "UPDATE_PLAYER",
+          updates: { bag: { ...state.player.bag } },
+        });
+        showMessages([...dialogue, `${item.name}を${quantity}個もらった！`]);
+        return;
+      }
+
+      // フラグ設定
+      if (npc.onInteract?.setFlags) {
+        for (const [flag, value] of Object.entries(npc.onInteract.setFlags)) {
+          dispatch({ type: "SET_STORY_FLAG", flag, value });
+        }
+      }
+
+      showMessages(dialogue);
+    },
+    [
+      currentMap,
+      state.player,
+      state.storyFlags,
+      dispatch,
+      showMessages,
+      gymLeaderNpcMap,
+      leagueNpcMap,
+      runEventScript,
+    ],
+  );
+
+  /** エンカウント処理 */
+  const handleEncounter = useCallback(() => {
+    if (!currentMap || !state.player) return;
+
+    const wildMon = processEncounter(currentMap, speciesResolver, moveResolver);
+    if (!wildMon) return;
+
+    // 図鑑に登録（見た）
+    const newSeen = new Set(state.player.pokedexSeen);
+    newSeen.add(wildMon.speciesId);
+    dispatch({ type: "UPDATE_PLAYER", updates: { pokedexSeen: newSeen } });
+
+    const wildSpecies = speciesResolver(wildMon.speciesId);
+
+    setWildMonster(wildMon);
+    setBattleMessages([`野生の${wildSpecies.name}が飛び出してきた！`]);
+    setIsBattleProcessing(true);
+
+    // BattleEngine生成（パーティのコピーではなく参照を渡す — エンジンが直接変更）
+    const engine = new BattleEngine(
+      state.player.partyState.party,
+      [wildMon],
+      "wild",
+      speciesResolver,
+      moveResolver,
+    );
+    setBattleEngine(engine);
+
+    dispatch({ type: "CHANGE_SCREEN", screen: "battle" });
+
+    // 開始メッセージの後にアクション選択へ
+    setTimeout(() => setIsBattleProcessing(false), 1500);
+  }, [currentMap, state.player, dispatch]);
+
+  /** メニューを開く */
+  const handleMenuOpen = useCallback(() => {
+    setOverlayScreen("menu");
+    setReturnScreen("overworld");
+  }, []);
+
+  // ==========================
+  // バトル関連
+  // ==========================
+
+  /** バトルアクション処理 */
+  const handleBattleAction = useCallback(
+    (action: BattleScreenAction) => {
+      if (!battleEngine || !state.player) return;
+
+      // バッグを開く
+      if (action.type === "bag") {
+        setBattleBagMode(true);
+        setOverlayScreen("bag");
+        setReturnScreen("battle");
+        return;
+      }
+
+      // ポケモン交代画面を開く
+      if (action.type === "pokemon") {
+        setBattlePartyMode(true);
+        setOverlayScreen("party");
+        setReturnScreen("battle");
+        return;
+      }
+
+      setIsBattleProcessing(true);
+
+      let engineAction: BattleAction;
+      if (action.type === "fight") {
+        engineAction = { type: "fight", moveIndex: action.moveIndex };
+      } else {
+        engineAction = { type: "run" };
+      }
+
+      const messages = battleEngine.executeTurn(engineAction);
+      setBattleMessages(messages);
+
+      // バトル終了チェック
+      setTimeout(() => {
+        if (battleEngine.state.result) {
+          handleBattleEnd();
+        } else if (battleEngine.state.phase === "force_switch") {
+          // 強制交代
+          setBattlePartyMode(true);
+          setOverlayScreen("party");
+          setReturnScreen("battle");
+          setIsBattleProcessing(false);
+        } else {
+          setIsBattleProcessing(false);
+        }
+      }, 1500);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [battleEngine, state.player],
+  );
+
+  /** バトル終了処理 */
+  const handleBattleEnd = useCallback(() => {
+    if (!battleEngine || !state.player) return;
+
+    const result = battleEngine.state.result;
+    const wasTrainerBattle = isTrainerBattle;
+
+    // パーティの状態を反映
+    dispatch({
+      type: "UPDATE_PLAYER",
+      updates: {
+        partyState: { ...state.player.partyState },
+      },
+    });
+
+    // レベルアップ時の技習得チェック
+    const checkLevelUpMoves = () => {
+      for (const monster of state.player!.partyState.party) {
+        const species = speciesResolver(monster.speciesId);
+        const learnable = getLearnableMoves(species, monster.level - 1, monster.level);
+        for (const entry of learnable) {
+          const moveDef = moveResolver(entry.moveId);
+          const learnResult = learnMove(monster, entry.moveId, moveDef);
+          if (learnResult === "full") {
+            setLearnMoveState({
+              monster,
+              moveId: entry.moveId,
+              moveName: moveDef.name,
+            });
+            return;
+          }
+        }
+      }
+    };
+
+    if (result?.type === "win" || result?.type === "run_success" || result?.type === "capture") {
+      checkLevelUpMoves();
+    }
+
+    // overworldに復帰
+    setBattleEngine(null);
+    setWildMonster(null);
+    setBattleMessages([]);
+    setIsBattleProcessing(false);
+    setIsTrainerBattle(false);
+    setTrainerBattleName(null);
+    dispatch({ type: "CHANGE_SCREEN", screen: "overworld" });
+
+    if (result?.type === "lose") {
+      // 全滅 → 町に戻って回復（イベントキューもクリア）
+      eventQueueRef.current = [];
+      isEventRunningRef.current = false;
+      dispatch({
+        type: "SET_OVERWORLD",
+        overworld: {
+          currentMapId: "wasuremachi",
+          playerX: 4,
+          playerY: 4,
+          direction: "down",
+        },
+      });
+      for (const monster of state.player.partyState.party) {
+        monster.currentHp = getMaxHp(monster);
+        monster.status = null;
+        for (const move of monster.moves) {
+          const moveDef = moveResolver(move.moveId);
+          move.currentPp = moveDef.pp;
+        }
+      }
+      dispatch({
+        type: "UPDATE_PLAYER",
+        updates: { partyState: { ...state.player.partyState } },
+      });
+      showMessages(["目の前が真っ暗になった…", "ワスレ町に戻された。"]);
+      return;
+    }
+
+    // トレーナーバトル勝利後: イベントキューの残りを処理
+    if (wasTrainerBattle && result?.type === "win") {
+      // チャンピオン撃破時にエンディングを実行
+      if (
+        state.storyFlags["champion_defeated"] !== true &&
+        trainerBattleName?.includes("チャンピオン")
+      ) {
+        // champion_defeatedフラグは後続のキューで設定される
+      }
+
+      setTimeout(() => {
+        processNextEvent();
+      }, 500);
+    }
+  }, [
+    battleEngine,
+    state.player,
+    state.storyFlags,
+    isTrainerBattle,
+    trainerBattleName,
+    dispatch,
+    showMessages,
+    processNextEvent,
+  ]);
+
+  // ==========================
+  // メニュー系画面処理
+  // ==========================
+
+  /** オーバーレイを閉じる */
+  const closeOverlay = useCallback(() => {
+    setOverlayScreen(null);
+    setBattleBagMode(false);
+    setBattlePartyMode(false);
+  }, []);
+
+  /** メニューからのナビゲーション */
+  const handleMenuNavigate = useCallback((screen: string) => {
+    setOverlayScreen(screen as OverlayScreen);
+  }, []);
+
+  /** セーブ処理 */
+  const handleSave = useCallback(() => {
+    if (!state.player) return;
+    const success = saveGame(state, 1);
+    showMessages([success ? "冒険の記録を書きました！" : "セーブに失敗しました…"], closeOverlay);
+  }, [state, showMessages, closeOverlay]);
+
+  /** パーティ並び替え */
+  const handlePartySwap = useCallback(
+    (indexA: number, indexB: number) => {
+      if (!state.player) return;
+      swapPartyOrder(state.player.partyState, indexA, indexB);
+      dispatch({
+        type: "UPDATE_PLAYER",
+        updates: { partyState: { ...state.player.partyState } },
+      });
+    },
+    [state.player, dispatch],
+  );
+
+  /** パーティ選択（バトル中交代） */
+  const handlePartySelect = useCallback(
+    (index: number) => {
+      if (!battleEngine || !state.player) return;
+
+      if (battleEngine.state.phase === "force_switch") {
+        const monster = state.player.partyState.party[index];
+        if (monster.currentHp <= 0) return;
+        const messages = battleEngine.forceSwitch(index);
+        setBattleMessages(messages);
+        closeOverlay();
+        setIsBattleProcessing(true);
+        setTimeout(() => setIsBattleProcessing(false), 1000);
+        return;
+      }
+
+      // 通常交代
+      const monster = state.player.partyState.party[index];
+      if (monster.currentHp <= 0 || index === battleEngine.state.player.activeIndex) return;
+
+      closeOverlay();
+      setIsBattleProcessing(true);
+
+      const messages = battleEngine.executeTurn({ type: "switch", partyIndex: index });
+      setBattleMessages(messages);
+
+      setTimeout(() => {
+        if (battleEngine.state.result) {
+          handleBattleEnd();
+        } else {
+          setIsBattleProcessing(false);
+        }
+      }, 1500);
+    },
+    [battleEngine, state.player, closeOverlay, handleBattleEnd],
+  );
+
+  /** バッグからアイテム使用 */
+  const handleBagUse = useCallback(
+    (itemId: string) => {
+      if (!state.player) return;
+
+      const item = itemResolver(itemId);
+
+      // バトル中のアイテム使用
+      if (battleBagMode && battleEngine) {
+        // ボール使用 → 捕獲フロー
+        if (item.effect.type === "ball" && wildMonster) {
+          if (!removeItem(state.player.bag, itemId)) return;
+          dispatch({
+            type: "UPDATE_PLAYER",
+            updates: { bag: { ...state.player.bag } },
+          });
+          closeOverlay();
+          setIsBattleProcessing(true);
+
+          const maxHp = getMaxHp(wildMonster);
+          const captureResult = executeCaptureFlow(
+            {
+              maxHp,
+              currentHp: wildMonster.currentHp,
+              baseCatchRate: 100, // デフォルト捕獲率
+              ballModifier: item.effect.catchRateModifier,
+              status: wildMonster.status,
+            },
+            wildMonster,
+            state.player.partyState,
+            item.name,
+          );
+
+          setBattleMessages(captureResult.messages);
+
+          if (captureResult.catchResult.caught) {
+            // 図鑑登録
+            const newCaught = new Set(state.player.pokedexCaught);
+            newCaught.add(wildMonster.speciesId);
+            dispatch({
+              type: "UPDATE_PLAYER",
+              updates: {
+                pokedexCaught: newCaught,
+                partyState: { ...state.player.partyState },
+              },
+            });
+
+            battleEngine.state.result = { type: "capture" };
+            setTimeout(() => handleBattleEnd(), 2000);
+          } else {
+            // 捕獲失敗 → 相手ターン
+            const msgs = battleEngine.executeTurn({ type: "item", itemId });
+            setBattleMessages((prev) => [...prev, ...msgs]);
+            setTimeout(() => {
+              if (battleEngine.state.result) {
+                handleBattleEnd();
+              } else {
+                setIsBattleProcessing(false);
+              }
+            }, 1500);
+          }
+          return;
+        }
+
+        // 回復アイテム使用（バトル中）
+        if (item.effect.type === "heal_hp" || item.effect.type === "heal_status") {
+          const active = battleEngine.playerActive;
+          const maxHp = getMaxHp(active);
+          const healResult = applyHealItem(item, active, maxHp, moveResolver);
+          if (!healResult.used) {
+            showMessages([healResult.message]);
+            return;
+          }
+          if (!removeItem(state.player.bag, itemId)) return;
+          dispatch({
+            type: "UPDATE_PLAYER",
+            updates: { bag: { ...state.player.bag } },
+          });
+          closeOverlay();
+          setIsBattleProcessing(true);
+
+          // アイテム使用後、相手ターン
+          const msgs = battleEngine.executeTurn({ type: "item", itemId });
+          setBattleMessages([healResult.message, ...msgs]);
+          setTimeout(() => {
+            if (battleEngine.state.result) {
+              handleBattleEnd();
+            } else {
+              setIsBattleProcessing(false);
+            }
+          }, 1500);
+          return;
+        }
+      }
+
+      // フィールドでの回復アイテム使用
+      if (item.effect.type === "heal_hp" || item.effect.type === "heal_status") {
+        // 簡易: 先頭のモンスターに使用
+        const target = state.player.partyState.party[0];
+        if (!target) return;
+        const maxHp = getMaxHp(target);
+        const healResult = applyHealItem(item, target, maxHp, moveResolver);
+        if (!healResult.used) {
+          showMessages([healResult.message]);
+          return;
+        }
+        if (!removeItem(state.player.bag, itemId)) return;
+        dispatch({
+          type: "UPDATE_PLAYER",
+          updates: {
+            bag: { ...state.player.bag },
+            partyState: { ...state.player.partyState },
+          },
+        });
+        showMessages([healResult.message]);
+      }
+    },
+    [
+      state.player,
+      battleBagMode,
+      battleEngine,
+      wildMonster,
+      dispatch,
+      closeOverlay,
+      showMessages,
+      handleBattleEnd,
+    ],
+  );
+
+  // ==========================
+  // 技習得UI
+  // ==========================
+  const handleLearnMoveChoice = useCallback(
+    (slotIndex: number) => {
+      if (!learnMoveState) return;
+      const { monster, moveId } = learnMoveState;
+      const moveDef = moveResolver(moveId);
+
+      if (slotIndex === -1) {
+        // 習得しない
+        showMessages([`${moveDef.name}を覚えるのをあきらめた。`]);
+      } else {
+        const old = moveResolver(monster.moves[slotIndex].moveId);
+        replaceMove(monster, slotIndex, moveId, moveDef);
+        showMessages([`${old.name}を忘れて${moveDef.name}を覚えた！`]);
+        if (state.player) {
+          dispatch({
+            type: "UPDATE_PLAYER",
+            updates: { partyState: { ...state.player.partyState } },
+          });
+        }
+      }
+      setLearnMoveState(null);
+    },
+    [learnMoveState, state.player, dispatch, showMessages],
+  );
+
+  // ==========================
+  // ロード処理（タイトルから）
+  // ==========================
+  const handleLoadGame = useCallback(() => {
+    const loaded = loadGame(1);
+    if (loaded) {
+      dispatch({ type: "LOAD_GAME", state: loaded });
+    } else {
+      showMessages(["セーブデータがありません。"]);
+    }
+  }, [dispatch, showMessages]);
+
+  // ==========================
+  // データ変換ヘルパー
+  // ==========================
+
+  const getPartyMemberInfos = useCallback((): PartyMemberInfo[] => {
+    if (!state.player) return [];
+    return state.player.partyState.party.map((m) => {
+      const species = speciesResolver(m.speciesId);
+      return {
+        speciesId: m.speciesId,
+        name: m.nickname ?? species.name,
+        level: m.level,
+        currentHp: m.currentHp,
+        maxHp: getMaxHp(m),
+        status: m.status,
+        types: species.types as string[],
+      };
+    });
+  }, [state.player]);
+
+  const getBagItemInfos = useCallback((): BagItemInfo[] => {
+    if (!state.player) return [];
+    return state.player.bag.items.map((bi) => {
+      const item = itemResolver(bi.itemId);
+      return {
+        itemId: bi.itemId,
+        name: item.name,
+        description: item.description,
+        category: item.category,
+        quantity: bi.quantity,
+        usable: item.effect.type !== "none",
+      };
+    });
+  }, [state.player]);
+
+  const getPokedexEntries = useCallback((): PokedexEntry[] => {
+    if (!state.player) return [];
+    return ALL_SPECIES.map((species) => ({
+      id: species.id,
+      name: species.name,
+      types: species.types as string[],
+      description: `${species.types.join("/")}タイプのモンスター。`,
+      seen: state.player!.pokedexSeen.has(species.id),
+      caught: state.player!.pokedexCaught.has(species.id),
+    }));
+  }, [state.player]);
+
+  // ==========================
+  // レンダリング
+  // ==========================
+
+  // 技習得UIを優先表示
+  if (learnMoveState) {
+    const { monster, moveName } = learnMoveState;
+    const species = speciesResolver(monster.speciesId);
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center bg-gray-950 p-8">
+        <h2 className="mb-4 font-mono text-xl text-white">
+          {species.name}は{moveName}を覚えたい！
+        </h2>
+        <p className="mb-6 font-mono text-gray-400">でも技は4つまでしか覚えられない…</p>
+        <div className="space-y-2">
+          {monster.moves.map((m, i) => {
+            const md = moveResolver(m.moveId);
+            return (
+              <button
+                key={m.moveId}
+                className="block w-64 rounded bg-gray-800 px-4 py-2 text-left font-mono text-white hover:bg-gray-700"
+                onClick={() => handleLearnMoveChoice(i)}
+              >
+                {md.name} ({md.type})
+              </button>
+            );
+          })}
+          <button
+            className="block w-64 rounded bg-red-900 px-4 py-2 text-left font-mono text-gray-300 hover:bg-red-800"
+            onClick={() => handleLearnMoveChoice(-1)}
+          >
+            {moveName}を覚えない
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // メッセージウィンドウ（オーバーレイ）
+  const messageOverlay = pendingMessages && (
+    <MessageWindow messages={pendingMessages} onComplete={handleMessageComplete} />
+  );
+
+  // オーバーレイ画面（メニュー系）
+  const renderOverlay = () => {
+    if (!state.player) return null;
+
+    switch (overlayScreen) {
+      case "menu":
+        return (
+          <MenuScreen
+            playerName={state.player.name}
+            badgeCount={state.player.badges.length}
+            onNavigate={handleMenuNavigate}
+            onSave={handleSave}
+            onBack={closeOverlay}
+          />
+        );
+      case "party":
+        return (
+          <PartyScreen
+            party={getPartyMemberInfos()}
+            onSwap={battlePartyMode ? undefined : handlePartySwap}
+            onSelect={
+              battlePartyMode || battleEngine?.state.phase === "force_switch"
+                ? handlePartySelect
+                : undefined
+            }
+            onBack={closeOverlay}
+            selectMode={battlePartyMode || battleEngine?.state.phase === "force_switch"}
+          />
+        );
+      case "bag":
+        return <BagScreen items={getBagItemInfos()} onUse={handleBagUse} onBack={closeOverlay} />;
+      case "pokedex":
+        return <PokedexScreen entries={getPokedexEntries()} onBack={closeOverlay} />;
+      default:
+        return null;
+    }
+  };
+
+  // メイン画面の描画
   switch (state.screen) {
     case "title":
       return (
-        <TitleScreen onNewGame={(name) => dispatch({ type: "START_NEW_GAME", playerName: name })} />
+        <TitleScreen
+          onNewGame={(name) => dispatch({ type: "START_NEW_GAME", playerName: name })}
+          onContinue={handleLoadGame}
+          hasSaveData={
+            typeof window !== "undefined" && localStorage.getItem("pokemon_save_1") !== null
+          }
+        />
       );
 
     case "starter_select":
@@ -62,24 +1076,102 @@ export function Game() {
         />
       );
 
-    case "overworld":
-      return (
-        <div className="flex min-h-screen items-center justify-center bg-gray-950">
-          <div className="text-center">
-            <p className="font-mono text-lg text-white">{state.player?.name}の冒険が始まった！</p>
-            <p className="mt-2 font-mono text-gray-400">
-              パーティ: {state.player?.partyState.party.map((m) => m.speciesId).join(", ")}
-            </p>
-            <p className="mt-4 font-mono text-sm text-gray-600">（オーバーワールドは開発中...）</p>
+    case "overworld": {
+      if (!currentMap || !state.overworld) {
+        return (
+          <div className="flex min-h-screen items-center justify-center bg-black">
+            <p className="font-mono text-white">マップを読み込み中...</p>
           </div>
-        </div>
+        );
+      }
+
+      const inputBlocked =
+        overlayScreen !== null || eventQueueRef.current.length > 0 || pendingMessages !== null;
+
+      return (
+        <>
+          <OverworldScreen
+            key={state.overworld.currentMapId}
+            map={currentMap}
+            initialPosition={{
+              x: state.overworld.playerX,
+              y: state.overworld.playerY,
+              direction: state.overworld.direction,
+            }}
+            storyFlags={state.storyFlags}
+            inputBlocked={inputBlocked}
+            onMapTransition={handleMapTransition}
+            onEncounter={handleEncounter}
+            onNpcInteract={handleNpcInteract}
+            onMenuOpen={handleMenuOpen}
+          />
+          {renderOverlay()}
+          {messageOverlay}
+        </>
       );
+    }
+
+    case "battle": {
+      if (!battleEngine || !state.player) {
+        return (
+          <div className="flex min-h-screen items-center justify-center bg-black">
+            <p className="font-mono text-white">バトル準備中...</p>
+          </div>
+        );
+      }
+
+      const playerActive = battleEngine.playerActive;
+      const opponentActive = battleEngine.opponentActive;
+      const playerSpecies = speciesResolver(playerActive.speciesId);
+      const opponentSpecies = speciesResolver(opponentActive.speciesId);
+
+      return (
+        <>
+          <BattleScreen
+            player={{
+              name: playerActive.nickname ?? playerSpecies.name,
+              level: playerActive.level,
+              currentHp: playerActive.currentHp,
+              maxHp: getMaxHp(playerActive),
+              isPlayer: true,
+            }}
+            opponent={{
+              name: opponentSpecies.name,
+              level: opponentActive.level,
+              currentHp: opponentActive.currentHp,
+              maxHp: getMaxHp(opponentActive),
+              isPlayer: false,
+            }}
+            moves={playerActive.moves.map((m) => {
+              const md = moveResolver(m.moveId);
+              return {
+                moveId: m.moveId,
+                name: md.name,
+                type: md.type,
+                currentPp: m.currentPp,
+                maxPp: md.pp,
+              };
+            })}
+            messages={battleMessages}
+            isWild={battleEngine.state.battleType === "wild"}
+            onAction={handleBattleAction}
+            isProcessing={isBattleProcessing}
+          />
+          {renderOverlay()}
+          {messageOverlay}
+        </>
+      );
+    }
 
     default:
       return (
-        <div className="flex min-h-screen items-center justify-center bg-black">
-          <p className="font-mono text-white">画面: {state.screen}（開発中）</p>
-        </div>
+        <>
+          <div className="flex min-h-screen items-center justify-center bg-black">
+            <p className="font-mono text-white">画面: {state.screen}（開発中）</p>
+          </div>
+          {renderOverlay()}
+          {messageOverlay}
+        </>
       );
   }
 }

--- a/src/data/maps/all-maps.ts
+++ b/src/data/maps/all-maps.ts
@@ -1,0 +1,756 @@
+/**
+ * 全マップデータ（ジム2〜8の町 + ルート + ポケモンリーグ）
+ * wasuremachi, route-1, hajimari-forest は個別ファイル
+ */
+import type { MapDefinition } from "@/engine/map/map-data";
+
+const W = "wall" as const;
+const G = "ground" as const;
+const T = "grass" as const;
+
+// ===== ツチグモ村（ジム1:ノーマル）=====
+export const TSUCHIGUMO_VILLAGE: MapDefinition = {
+  id: "tsuchigumo-village",
+  name: "ツチグモ村",
+  width: 10,
+  height: 10,
+  tiles: [
+    [W, W, W, W, W, G, G, W, W, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, G, W, G, G, G, G, W, G, W],
+    [W, G, W, G, G, G, G, W, G, W],
+    [G, G, G, G, G, G, G, G, G, G],
+    [G, G, G, G, G, G, G, G, G, G],
+    [W, G, W, G, G, G, G, W, G, W],
+    [W, G, W, G, G, G, G, W, G, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, W, W, W, G, G, W, W, W, W],
+  ],
+  connections: [
+    { targetMapId: "hajimari-forest", targetX: 5, targetY: 10, sourceX: 5, sourceY: 0 },
+    { targetMapId: "hajimari-forest", targetX: 6, targetY: 10, sourceX: 6, sourceY: 0 },
+    { targetMapId: "route-2", targetX: 4, targetY: 0, sourceX: 4, sourceY: 9 },
+    { targetMapId: "route-2", targetX: 5, targetY: 0, sourceX: 5, sourceY: 9 },
+  ],
+  encounters: [],
+  encounterRate: 0,
+  npcs: [
+    {
+      id: "npc-gym1-healer",
+      name: "回復のおねえさん",
+      x: 2,
+      y: 3,
+      dialogue: ["モンスターを回復しますね！"],
+      isTrainer: false,
+      onInteract: { heal: true },
+    },
+    {
+      id: "npc-gym1-leader",
+      name: "マサキ",
+      x: 8,
+      y: 3,
+      dialogue: [
+        "やあ、新しい挑戦者だね。",
+        "僕はマサキ。この島で一番最初の試練を担当している。",
+        "それを見せてくれ！",
+      ],
+      isTrainer: true,
+      onInteract: { setFlags: { gym1_battle_triggered: true } },
+    },
+  ],
+};
+
+// ===== ルート2 =====
+export const ROUTE_2: MapDefinition = {
+  id: "route-2",
+  name: "ルート2",
+  width: 12,
+  height: 10,
+  tiles: [
+    [W, W, W, W, G, G, W, W, W, W, W, W],
+    [W, T, T, G, G, G, G, G, T, T, T, W],
+    [W, T, T, G, G, G, G, G, T, T, T, W],
+    [W, G, G, G, G, G, G, G, G, G, G, W],
+    [W, G, G, G, W, W, G, G, G, G, G, W],
+    [W, G, G, G, W, W, G, G, G, G, G, W],
+    [W, G, T, T, G, G, G, T, T, G, G, W],
+    [W, G, T, T, G, G, G, T, T, G, G, W],
+    [W, G, G, G, G, G, G, G, G, G, G, W],
+    [W, W, W, W, W, G, G, W, W, W, W, W],
+  ],
+  connections: [
+    { targetMapId: "tsuchigumo-village", targetX: 4, targetY: 8, sourceX: 4, sourceY: 0 },
+    { targetMapId: "tsuchigumo-village", targetX: 5, targetY: 8, sourceX: 5, sourceY: 0 },
+    { targetMapId: "morinoha-town", targetX: 5, targetY: 0, sourceX: 5, sourceY: 9 },
+    { targetMapId: "morinoha-town", targetX: 6, targetY: 0, sourceX: 6, sourceY: 9 },
+  ],
+  encounters: [
+    { speciesId: "konezumi", minLevel: 7, maxLevel: 10, weight: 25 },
+    { speciesId: "tobibato", minLevel: 7, maxLevel: 10, weight: 25 },
+    { speciesId: "mayumushi", minLevel: 7, maxLevel: 10, weight: 25 },
+    { speciesId: "dokudama", minLevel: 7, maxLevel: 10, weight: 15 },
+    { speciesId: "hikarineko", minLevel: 8, maxLevel: 11, weight: 10 },
+  ],
+  encounterRate: 20,
+  npcs: [],
+};
+
+// ===== モリノハの町（ジム2:虫）=====
+export const MORINOHA_TOWN: MapDefinition = {
+  id: "morinoha-town",
+  name: "モリノハの町",
+  width: 10,
+  height: 10,
+  tiles: [
+    [W, W, W, W, W, G, G, W, W, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, G, W, G, G, G, G, W, G, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [G, G, G, G, G, G, G, G, G, G],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, G, W, G, G, G, G, W, G, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, W, W, W, G, G, W, W, W, W],
+  ],
+  connections: [
+    { targetMapId: "route-2", targetX: 5, targetY: 8, sourceX: 5, sourceY: 0 },
+    { targetMapId: "route-2", targetX: 6, targetY: 8, sourceX: 6, sourceY: 0 },
+    { targetMapId: "route-3", targetX: 4, targetY: 0, sourceX: 4, sourceY: 9 },
+    { targetMapId: "route-3", targetX: 5, targetY: 0, sourceX: 5, sourceY: 9 },
+  ],
+  encounters: [],
+  encounterRate: 0,
+  npcs: [
+    {
+      id: "npc-gym2-healer",
+      name: "回復のおねえさん",
+      x: 2,
+      y: 3,
+      dialogue: ["回復しますね！"],
+      isTrainer: false,
+      onInteract: { heal: true },
+    },
+    {
+      id: "npc-gym2-leader",
+      name: "カイコ",
+      x: 8,
+      y: 3,
+      dialogue: ["虫タイプの研究をしているの。挑戦する？"],
+      isTrainer: true,
+    },
+  ],
+};
+
+// ===== ルート3 =====
+export const ROUTE_3: MapDefinition = {
+  id: "route-3",
+  name: "ルート3",
+  width: 12,
+  height: 10,
+  tiles: [
+    [W, W, W, W, G, G, W, W, W, W, W, W],
+    [W, G, T, T, G, G, G, G, T, T, G, W],
+    [W, G, T, T, G, G, G, G, T, T, G, W],
+    [W, G, G, G, G, G, G, G, G, G, G, W],
+    [W, G, G, G, G, G, G, G, G, G, G, W],
+    [W, G, G, T, T, G, G, G, T, T, G, W],
+    [W, G, G, T, T, G, G, G, T, T, G, W],
+    [W, G, G, G, G, G, G, G, G, G, G, W],
+    [W, G, G, G, G, G, G, G, G, G, G, W],
+    [W, W, W, W, W, G, G, W, W, W, W, W],
+  ],
+  connections: [
+    { targetMapId: "morinoha-town", targetX: 4, targetY: 8, sourceX: 4, sourceY: 0 },
+    { targetMapId: "morinoha-town", targetX: 5, targetY: 8, sourceX: 5, sourceY: 0 },
+    { targetMapId: "inazuma-city", targetX: 5, targetY: 0, sourceX: 5, sourceY: 9 },
+    { targetMapId: "inazuma-city", targetX: 6, targetY: 0, sourceX: 6, sourceY: 9 },
+  ],
+  encounters: [
+    { speciesId: "tobibato", minLevel: 12, maxLevel: 15, weight: 20 },
+    { speciesId: "dokudama", minLevel: 12, maxLevel: 16, weight: 20 },
+    { speciesId: "hikarineko", minLevel: 13, maxLevel: 16, weight: 15 },
+    { speciesId: "kawadojou", minLevel: 12, maxLevel: 15, weight: 20 },
+    { speciesId: "hidane", minLevel: 14, maxLevel: 17, weight: 15 },
+    { speciesId: "hanausagi", minLevel: 13, maxLevel: 16, weight: 10 },
+  ],
+  encounterRate: 22,
+  npcs: [],
+};
+
+// ===== イナヅマシティ（ジム3:電気）=====
+export const INAZUMA_CITY: MapDefinition = {
+  id: "inazuma-city",
+  name: "イナヅマシティ",
+  width: 10,
+  height: 10,
+  tiles: [
+    [W, W, W, W, W, G, G, W, W, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, G, W, G, G, G, G, W, G, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [G, G, G, G, G, G, G, G, G, G],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, G, W, G, G, G, G, W, G, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, W, W, W, G, G, W, W, W, W],
+  ],
+  connections: [
+    { targetMapId: "route-3", targetX: 5, targetY: 8, sourceX: 5, sourceY: 0 },
+    { targetMapId: "route-3", targetX: 6, targetY: 8, sourceX: 6, sourceY: 0 },
+    { targetMapId: "route-4", targetX: 4, targetY: 0, sourceX: 4, sourceY: 9 },
+    { targetMapId: "route-4", targetX: 5, targetY: 0, sourceX: 5, sourceY: 9 },
+  ],
+  encounters: [],
+  encounterRate: 0,
+  npcs: [
+    {
+      id: "npc-gym3-healer",
+      name: "回復のおねえさん",
+      x: 2,
+      y: 3,
+      dialogue: ["回復しますね！"],
+      isTrainer: false,
+      onInteract: { heal: true },
+    },
+    {
+      id: "npc-gym3-leader",
+      name: "ライゾウ",
+      x: 8,
+      y: 3,
+      dialogue: ["ビリビリ来るぜ！挑戦するか！"],
+      isTrainer: true,
+    },
+  ],
+};
+
+// ===== ルート4 =====
+export const ROUTE_4: MapDefinition = {
+  id: "route-4",
+  name: "ルート4",
+  width: 12,
+  height: 10,
+  tiles: [
+    [W, W, W, W, G, G, W, W, W, W, W, W],
+    [W, T, T, G, G, G, G, G, T, T, G, W],
+    [W, T, T, G, G, G, G, G, T, T, G, W],
+    [W, G, G, G, G, G, G, G, G, G, G, W],
+    [W, G, G, G, G, G, G, G, G, G, G, W],
+    [W, G, G, T, T, T, G, G, G, T, T, W],
+    [W, G, G, T, T, T, G, G, G, T, T, W],
+    [W, G, G, G, G, G, G, G, G, G, G, W],
+    [W, G, G, G, G, G, G, G, G, G, G, W],
+    [W, W, W, W, W, G, G, W, W, W, W, W],
+  ],
+  connections: [
+    { targetMapId: "inazuma-city", targetX: 4, targetY: 8, sourceX: 4, sourceY: 0 },
+    { targetMapId: "inazuma-city", targetX: 5, targetY: 8, sourceX: 5, sourceY: 0 },
+    { targetMapId: "kagari-city", targetX: 5, targetY: 0, sourceX: 5, sourceY: 9 },
+    { targetMapId: "kagari-city", targetX: 6, targetY: 0, sourceX: 6, sourceY: 9 },
+  ],
+  encounters: [
+    { speciesId: "hidane", minLevel: 18, maxLevel: 22, weight: 20 },
+    { speciesId: "kaenjishi", minLevel: 20, maxLevel: 24, weight: 10 },
+    { speciesId: "tsuchikobushi", minLevel: 18, maxLevel: 22, weight: 20 },
+    { speciesId: "mogurakko", minLevel: 18, maxLevel: 22, weight: 20 },
+    { speciesId: "kusakabi", minLevel: 19, maxLevel: 23, weight: 15 },
+    { speciesId: "kanamori", minLevel: 20, maxLevel: 24, weight: 15 },
+  ],
+  encounterRate: 22,
+  npcs: [],
+};
+
+// ===== カガリ市（ジム4:炎）=====
+export const KAGARI_CITY: MapDefinition = {
+  id: "kagari-city",
+  name: "カガリ市",
+  width: 10,
+  height: 10,
+  tiles: [
+    [W, W, W, W, W, G, G, W, W, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, G, W, G, G, G, G, W, G, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [G, G, G, G, G, G, G, G, G, G],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, G, W, G, G, G, G, W, G, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, W, W, W, G, G, W, W, W, W],
+  ],
+  connections: [
+    { targetMapId: "route-4", targetX: 5, targetY: 8, sourceX: 5, sourceY: 0 },
+    { targetMapId: "route-4", targetX: 6, targetY: 8, sourceX: 6, sourceY: 0 },
+    { targetMapId: "route-5", targetX: 4, targetY: 0, sourceX: 4, sourceY: 9 },
+    { targetMapId: "route-5", targetX: 5, targetY: 0, sourceX: 5, sourceY: 9 },
+  ],
+  encounters: [],
+  encounterRate: 0,
+  npcs: [
+    {
+      id: "npc-gym4-healer",
+      name: "回復のおねえさん",
+      x: 2,
+      y: 3,
+      dialogue: ["回復しますね！"],
+      isTrainer: false,
+      onInteract: { heal: true },
+    },
+    {
+      id: "npc-gym4-leader",
+      name: "カガリ",
+      x: 8,
+      y: 3,
+      dialogue: ["お前の心に火はあるか？"],
+      isTrainer: true,
+    },
+  ],
+};
+
+// ===== ルート5 =====
+export const ROUTE_5: MapDefinition = {
+  id: "route-5",
+  name: "ルート5",
+  width: 12,
+  height: 10,
+  tiles: [
+    [W, W, W, W, G, G, W, W, W, W, W, W],
+    [W, G, T, T, G, G, G, T, T, G, G, W],
+    [W, G, T, T, G, G, G, T, T, G, G, W],
+    [W, G, G, G, G, G, G, G, G, G, G, W],
+    [W, G, G, G, G, G, G, G, G, G, G, W],
+    [W, G, T, T, G, G, G, G, T, T, G, W],
+    [W, G, T, T, G, G, G, G, T, T, G, W],
+    [W, G, G, G, G, G, G, G, G, G, G, W],
+    [W, G, G, G, G, G, G, G, G, G, G, W],
+    [W, W, W, W, W, G, G, W, W, W, W, W],
+  ],
+  connections: [
+    { targetMapId: "kagari-city", targetX: 4, targetY: 8, sourceX: 4, sourceY: 0 },
+    { targetMapId: "kagari-city", targetX: 5, targetY: 8, sourceX: 5, sourceY: 0 },
+    { targetMapId: "gouki-town", targetX: 5, targetY: 0, sourceX: 5, sourceY: 9 },
+    { targetMapId: "gouki-town", targetX: 6, targetY: 0, sourceX: 6, sourceY: 9 },
+  ],
+  encounters: [
+    { speciesId: "tsuchikobushi", minLevel: 24, maxLevel: 28, weight: 20 },
+    { speciesId: "iwakenjin", minLevel: 26, maxLevel: 30, weight: 10 },
+    { speciesId: "yurabi", minLevel: 24, maxLevel: 28, weight: 20 },
+    { speciesId: "yamigarasu", minLevel: 25, maxLevel: 29, weight: 15 },
+    { speciesId: "kanamori", minLevel: 25, maxLevel: 29, weight: 15 },
+    { speciesId: "dokubana", minLevel: 26, maxLevel: 30, weight: 20 },
+  ],
+  encounterRate: 22,
+  npcs: [],
+};
+
+// ===== ゴウキの町（ジム5:格闘）=====
+export const GOUKI_TOWN: MapDefinition = {
+  id: "gouki-town",
+  name: "ゴウキの町",
+  width: 10,
+  height: 10,
+  tiles: [
+    [W, W, W, W, W, G, G, W, W, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, G, W, G, G, G, G, W, G, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [G, G, G, G, G, G, G, G, G, G],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, G, W, G, G, G, G, W, G, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, W, W, W, G, G, W, W, W, W],
+  ],
+  connections: [
+    { targetMapId: "route-5", targetX: 5, targetY: 8, sourceX: 5, sourceY: 0 },
+    { targetMapId: "route-5", targetX: 6, targetY: 8, sourceX: 6, sourceY: 0 },
+    { targetMapId: "route-6", targetX: 4, targetY: 0, sourceX: 4, sourceY: 9 },
+    { targetMapId: "route-6", targetX: 5, targetY: 0, sourceX: 5, sourceY: 9 },
+  ],
+  encounters: [],
+  encounterRate: 0,
+  npcs: [
+    {
+      id: "npc-gym5-healer",
+      name: "回復のおねえさん",
+      x: 2,
+      y: 3,
+      dialogue: ["回復しますね！"],
+      isTrainer: false,
+      onInteract: { heal: true },
+    },
+    {
+      id: "npc-gym5-leader",
+      name: "ゴウキ",
+      x: 8,
+      y: 3,
+      dialogue: ["言葉はいらぬ。拳で語り合おう。"],
+      isTrainer: true,
+    },
+  ],
+};
+
+// ===== ルート6 =====
+export const ROUTE_6: MapDefinition = {
+  id: "route-6",
+  name: "ルート6",
+  width: 12,
+  height: 10,
+  tiles: [
+    [W, W, W, W, G, G, W, W, W, W, W, W],
+    [W, T, T, G, G, G, G, G, T, T, G, W],
+    [W, T, T, G, G, G, G, G, T, T, G, W],
+    [W, G, G, G, G, G, G, G, G, G, G, W],
+    [W, G, G, G, G, G, G, G, G, G, G, W],
+    [W, G, T, T, T, G, G, T, T, T, G, W],
+    [W, G, T, T, T, G, G, T, T, T, G, W],
+    [W, G, G, G, G, G, G, G, G, G, G, W],
+    [W, G, G, G, G, G, G, G, G, G, G, W],
+    [W, W, W, W, W, G, G, W, W, W, W, W],
+  ],
+  connections: [
+    { targetMapId: "gouki-town", targetX: 4, targetY: 8, sourceX: 4, sourceY: 0 },
+    { targetMapId: "gouki-town", targetX: 5, targetY: 8, sourceX: 5, sourceY: 0 },
+    { targetMapId: "kirifuri-village", targetX: 5, targetY: 0, sourceX: 5, sourceY: 9 },
+    { targetMapId: "kirifuri-village", targetX: 6, targetY: 0, sourceX: 6, sourceY: 9 },
+  ],
+  encounters: [
+    { speciesId: "yurabi", minLevel: 30, maxLevel: 34, weight: 20 },
+    { speciesId: "kageboushi", minLevel: 31, maxLevel: 35, weight: 15 },
+    { speciesId: "kurooni", minLevel: 30, maxLevel: 34, weight: 15 },
+    { speciesId: "yamigarasu", minLevel: 30, maxLevel: 34, weight: 15 },
+    { speciesId: "fubukirei", minLevel: 32, maxLevel: 36, weight: 10 },
+    { speciesId: "tsukiusagi", minLevel: 31, maxLevel: 35, weight: 15 },
+    { speciesId: "dokubana", minLevel: 30, maxLevel: 34, weight: 10 },
+  ],
+  encounterRate: 25,
+  npcs: [],
+};
+
+// ===== キリフリ村（ジム6:ゴースト）=====
+export const KIRIFURI_VILLAGE: MapDefinition = {
+  id: "kirifuri-village",
+  name: "キリフリ村",
+  width: 10,
+  height: 10,
+  tiles: [
+    [W, W, W, W, W, G, G, W, W, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, G, W, G, G, G, G, W, G, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [G, G, G, G, G, G, G, G, G, G],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, G, W, G, G, G, G, W, G, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, W, W, W, G, G, W, W, W, W],
+  ],
+  connections: [
+    { targetMapId: "route-6", targetX: 5, targetY: 8, sourceX: 5, sourceY: 0 },
+    { targetMapId: "route-6", targetX: 6, targetY: 8, sourceX: 6, sourceY: 0 },
+    { targetMapId: "route-7", targetX: 4, targetY: 0, sourceX: 4, sourceY: 9 },
+    { targetMapId: "route-7", targetX: 5, targetY: 0, sourceX: 5, sourceY: 9 },
+  ],
+  encounters: [],
+  encounterRate: 0,
+  npcs: [
+    {
+      id: "npc-gym6-healer",
+      name: "回復のおねえさん",
+      x: 2,
+      y: 3,
+      dialogue: ["回復しますね！"],
+      isTrainer: false,
+      onInteract: { heal: true },
+    },
+    {
+      id: "npc-gym6-leader",
+      name: "キリフリ",
+      x: 8,
+      y: 3,
+      dialogue: ["ふふ…よく来たわね。"],
+      isTrainer: true,
+    },
+  ],
+};
+
+// ===== ルート7 =====
+export const ROUTE_7: MapDefinition = {
+  id: "route-7",
+  name: "ルート7",
+  width: 12,
+  height: 10,
+  tiles: [
+    [W, W, W, W, G, G, W, W, W, W, W, W],
+    [W, T, T, G, G, G, G, T, T, G, G, W],
+    [W, T, T, G, G, G, G, T, T, G, G, W],
+    [W, G, G, G, G, G, G, G, G, G, G, W],
+    [W, G, G, T, T, G, G, G, T, T, G, W],
+    [W, G, G, T, T, G, G, G, T, T, G, W],
+    [W, G, G, G, G, G, G, G, G, G, G, W],
+    [W, G, G, G, G, G, G, G, G, G, G, W],
+    [W, G, G, G, G, G, G, G, G, G, G, W],
+    [W, W, W, W, W, G, G, W, W, W, W, W],
+  ],
+  connections: [
+    { targetMapId: "kirifuri-village", targetX: 4, targetY: 8, sourceX: 4, sourceY: 0 },
+    { targetMapId: "kirifuri-village", targetX: 5, targetY: 8, sourceX: 5, sourceY: 0 },
+    { targetMapId: "fuyuha-town", targetX: 5, targetY: 0, sourceX: 5, sourceY: 9 },
+    { targetMapId: "fuyuha-town", targetX: 6, targetY: 0, sourceX: 6, sourceY: 9 },
+  ],
+  encounters: [
+    { speciesId: "yukiusagi", minLevel: 34, maxLevel: 38, weight: 25 },
+    { speciesId: "kogoriiwa", minLevel: 35, maxLevel: 39, weight: 15 },
+    { speciesId: "fubukirei", minLevel: 35, maxLevel: 39, weight: 15 },
+    { speciesId: "kiokudama", minLevel: 34, maxLevel: 38, weight: 15 },
+    { speciesId: "denjimushi", minLevel: 35, maxLevel: 39, weight: 15 },
+    { speciesId: "tatsunoko", minLevel: 36, maxLevel: 40, weight: 15 },
+  ],
+  encounterRate: 22,
+  npcs: [],
+};
+
+// ===== フユハの町（ジム7:氷）=====
+export const FUYUHA_TOWN: MapDefinition = {
+  id: "fuyuha-town",
+  name: "フユハの町",
+  width: 10,
+  height: 10,
+  tiles: [
+    [W, W, W, W, W, G, G, W, W, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, G, W, G, G, G, G, W, G, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [G, G, G, G, G, G, G, G, G, G],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, G, W, G, G, G, G, W, G, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, W, W, W, G, G, W, W, W, W],
+  ],
+  connections: [
+    { targetMapId: "route-7", targetX: 5, targetY: 8, sourceX: 5, sourceY: 0 },
+    { targetMapId: "route-7", targetX: 6, targetY: 8, sourceX: 6, sourceY: 0 },
+    { targetMapId: "route-8", targetX: 4, targetY: 0, sourceX: 4, sourceY: 9 },
+    { targetMapId: "route-8", targetX: 5, targetY: 0, sourceX: 5, sourceY: 9 },
+  ],
+  encounters: [],
+  encounterRate: 0,
+  npcs: [
+    {
+      id: "npc-gym7-healer",
+      name: "回復のおねえさん",
+      x: 2,
+      y: 3,
+      dialogue: ["回復しますね！"],
+      isTrainer: false,
+      onInteract: { heal: true },
+    },
+    {
+      id: "npc-gym7-leader",
+      name: "フユハ",
+      x: 8,
+      y: 3,
+      dialogue: ["氷は記憶を閉じ込める。"],
+      isTrainer: true,
+    },
+  ],
+};
+
+// ===== ルート8 =====
+export const ROUTE_8: MapDefinition = {
+  id: "route-8",
+  name: "ルート8",
+  width: 12,
+  height: 10,
+  tiles: [
+    [W, W, W, W, G, G, W, W, W, W, W, W],
+    [W, T, T, G, G, G, G, T, T, G, G, W],
+    [W, T, T, G, G, G, G, T, T, G, G, W],
+    [W, G, G, G, G, G, G, G, G, G, G, W],
+    [W, G, G, T, T, G, G, T, T, G, G, W],
+    [W, G, G, T, T, G, G, T, T, G, G, W],
+    [W, G, G, G, G, G, G, G, G, G, G, W],
+    [W, G, G, G, G, G, G, G, G, G, G, W],
+    [W, G, G, G, G, G, G, G, G, G, G, W],
+    [W, W, W, W, W, G, G, W, W, W, W, W],
+  ],
+  connections: [
+    { targetMapId: "fuyuha-town", targetX: 4, targetY: 8, sourceX: 4, sourceY: 0 },
+    { targetMapId: "fuyuha-town", targetX: 5, targetY: 8, sourceX: 5, sourceY: 0 },
+    { targetMapId: "tatsumi-city", targetX: 5, targetY: 0, sourceX: 5, sourceY: 9 },
+    { targetMapId: "tatsumi-city", targetX: 6, targetY: 0, sourceX: 6, sourceY: 9 },
+  ],
+  encounters: [
+    { speciesId: "tatsunoko", minLevel: 38, maxLevel: 42, weight: 20 },
+    { speciesId: "ryuubi", minLevel: 40, maxLevel: 44, weight: 10 },
+    { speciesId: "haganedake", minLevel: 39, maxLevel: 43, weight: 15 },
+    { speciesId: "umihebi", minLevel: 39, maxLevel: 43, weight: 15 },
+    { speciesId: "raijindou", minLevel: 40, maxLevel: 44, weight: 10 },
+    { speciesId: "koorigitsune", minLevel: 38, maxLevel: 42, weight: 15 },
+    { speciesId: "omoidama", minLevel: 39, maxLevel: 43, weight: 15 },
+  ],
+  encounterRate: 25,
+  npcs: [],
+};
+
+// ===== タツミシティ（ジム8:ドラゴン）=====
+export const TATSUMI_CITY: MapDefinition = {
+  id: "tatsumi-city",
+  name: "タツミシティ",
+  width: 10,
+  height: 10,
+  tiles: [
+    [W, W, W, W, W, G, G, W, W, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, G, W, G, G, G, G, W, G, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [G, G, G, G, G, G, G, G, G, G],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, G, W, G, G, G, G, W, G, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, W, W, W, G, G, W, W, W, W],
+  ],
+  connections: [
+    { targetMapId: "route-8", targetX: 5, targetY: 8, sourceX: 5, sourceY: 0 },
+    { targetMapId: "route-8", targetX: 6, targetY: 8, sourceX: 6, sourceY: 0 },
+    {
+      targetMapId: "pokemon-league",
+      targetX: 5,
+      targetY: 0,
+      sourceX: 4,
+      sourceY: 9,
+      requirement: "gym8_cleared",
+      blockedMessage: "全てのバッジが必要だ…",
+    },
+    {
+      targetMapId: "pokemon-league",
+      targetX: 6,
+      targetY: 0,
+      sourceX: 5,
+      sourceY: 9,
+      requirement: "gym8_cleared",
+      blockedMessage: "全てのバッジが必要だ…",
+    },
+  ],
+  encounters: [],
+  encounterRate: 0,
+  npcs: [
+    {
+      id: "npc-gym8-healer",
+      name: "回復のおねえさん",
+      x: 2,
+      y: 3,
+      dialogue: ["回復しますね！"],
+      isTrainer: false,
+      onInteract: { heal: true },
+    },
+    {
+      id: "npc-gym8-leader",
+      name: "タツミ",
+      x: 8,
+      y: 3,
+      dialogue: ["竜の試練に挑むか。覚悟はいいか。"],
+      isTrainer: true,
+    },
+  ],
+};
+
+// ===== ポケモンリーグ =====
+export const POKEMON_LEAGUE: MapDefinition = {
+  id: "pokemon-league",
+  name: "ポケモンリーグ",
+  width: 10,
+  height: 10,
+  tiles: [
+    [W, W, W, W, W, G, G, W, W, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, G, G, G, G, G, G, G, G, W],
+    [W, W, W, W, W, W, W, W, W, W],
+  ],
+  connections: [
+    { targetMapId: "tatsumi-city", targetX: 4, targetY: 8, sourceX: 5, sourceY: 0 },
+    { targetMapId: "tatsumi-city", targetX: 5, targetY: 8, sourceX: 6, sourceY: 0 },
+  ],
+  encounters: [],
+  encounterRate: 0,
+  npcs: [
+    {
+      id: "npc-league-healer",
+      name: "回復のおねえさん",
+      x: 2,
+      y: 7,
+      dialogue: ["四天王に挑む前に回復しますね！"],
+      isTrainer: false,
+      onInteract: { heal: true },
+    },
+    {
+      id: "npc-league-elite1",
+      name: "四天王 ツバサ",
+      x: 5,
+      y: 6,
+      dialogue: ["風のように自由に生きる吟遊詩人。挑戦を受けよう。"],
+      isTrainer: true,
+    },
+    {
+      id: "npc-league-elite2",
+      name: "四天王 クロガネ",
+      x: 5,
+      y: 5,
+      dialogue: ["鋼は錆びぬ。鋼は折れぬ。鋼は忘れぬ。"],
+      isTrainer: true,
+    },
+    {
+      id: "npc-league-elite3",
+      name: "四天王 ミヤビ",
+      x: 5,
+      y: 4,
+      dialogue: ["あなたの物語の結末を見届けてあげる。"],
+      isTrainer: true,
+    },
+    {
+      id: "npc-league-elite4",
+      name: "四天王 ゲンブ",
+      x: 5,
+      y: 3,
+      dialogue: ["大地の記憶に刻まれるほどの戦いを見せろ。"],
+      isTrainer: true,
+    },
+    {
+      id: "npc-league-champion",
+      name: "チャンピオン アカツキ",
+      x: 5,
+      y: 2,
+      dialogue: ["…来たか。最後の勝負だ。"],
+      isTrainer: true,
+    },
+  ],
+};
+
+/** 追加マップの一覧 */
+export const ADDITIONAL_MAPS: Record<string, MapDefinition> = {
+  "tsuchigumo-village": TSUCHIGUMO_VILLAGE,
+  "route-2": ROUTE_2,
+  "morinoha-town": MORINOHA_TOWN,
+  "route-3": ROUTE_3,
+  "inazuma-city": INAZUMA_CITY,
+  "route-4": ROUTE_4,
+  "kagari-city": KAGARI_CITY,
+  "route-5": ROUTE_5,
+  "gouki-town": GOUKI_TOWN,
+  "route-6": ROUTE_6,
+  "kirifuri-village": KIRIFURI_VILLAGE,
+  "route-7": ROUTE_7,
+  "fuyuha-town": FUYUHA_TOWN,
+  "route-8": ROUTE_8,
+  "tatsumi-city": TATSUMI_CITY,
+  "pokemon-league": POKEMON_LEAGUE,
+};

--- a/src/engine/state/__tests__/game-state.test.ts
+++ b/src/engine/state/__tests__/game-state.test.ts
@@ -29,7 +29,11 @@ describe("ゲーム状態管理", () => {
     expect(player.name).toBe("サトシ");
     expect(player.money).toBe(3000);
     expect(player.partyState.party).toHaveLength(0);
-    expect(player.bag.items).toHaveLength(0);
+    expect(player.bag.items).toHaveLength(2);
+    expect(player.bag.items).toEqual([
+      { itemId: "monster-ball", quantity: 5 },
+      { itemId: "potion", quantity: 3 },
+    ]);
   });
 
   describe("gameReducer", () => {

--- a/src/engine/state/game-state.ts
+++ b/src/engine/state/game-state.ts
@@ -63,7 +63,12 @@ export function createNewPlayerState(name: string): PlayerState {
       party: [],
       boxes: Array.from({ length: 8 }, () => []),
     },
-    bag: { items: [] },
+    bag: {
+      items: [
+        { itemId: "monster-ball", quantity: 5 },
+        { itemId: "potion", quantity: 3 },
+      ],
+    },
     pokedexSeen: new Set(),
     pokedexCaught: new Set(),
   };
@@ -75,7 +80,9 @@ export type GameAction =
   | { type: "SET_STARTER"; monster: MonsterInstance }
   | { type: "UPDATE_PLAYER"; updates: Partial<PlayerState> }
   | { type: "SET_STORY_FLAG"; flag: string; value: boolean }
-  | { type: "LOAD_GAME"; state: GameState };
+  | { type: "LOAD_GAME"; state: GameState }
+  | { type: "UPDATE_OVERWORLD"; updates: Partial<OverworldState> }
+  | { type: "SET_OVERWORLD"; overworld: OverworldState };
 
 /** ゲーム状態のReducer */
 export function gameReducer(state: GameState, action: GameAction): GameState {
@@ -102,6 +109,12 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
           pokedexSeen: new Set([...state.player.pokedexSeen, action.monster.speciesId]),
           pokedexCaught: new Set([...state.player.pokedexCaught, action.monster.speciesId]),
         },
+        overworld: {
+          currentMapId: "wasuremachi",
+          playerX: 4,
+          playerY: 4,
+          direction: "down" as const,
+        },
       };
     case "UPDATE_PLAYER":
       if (!state.player) return state;
@@ -116,6 +129,17 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
       };
     case "LOAD_GAME":
       return action.state;
+    case "UPDATE_OVERWORLD":
+      if (!state.overworld) return state;
+      return {
+        ...state,
+        overworld: { ...state.overworld, ...action.updates },
+      };
+    case "SET_OVERWORLD":
+      return {
+        ...state,
+        overworld: action.overworld,
+      };
     default:
       return state;
   }


### PR DESCRIPTION
## Summary
- **Fix 1**: ポケモンリーグに四天王4人（ツバサ, クロガネ, ミヤビ, ゲンブ）のNPCを追加し、チャンピオン名をアカツキに修正
- **Fix 2**: OverworldScreenに`inputBlocked`プロップを追加し、メッセージ/イベント/オーバーレイ表示中のキー入力漏れを防止
- **Fix 3**: `isEventRunningRef`によるイベント再発火防止ガードを追加（大忘却イベント・エンディング等の重複実行を防止）
- **Fix 4**: 初期アイテムとしてモンスターボール5個・キズぐすり3個を付与

## Test plan
- [x] `bun run type-check` — 型エラーなし
- [x] `bun run lint` — lintエラーなし
- [x] `bun run format` — フォーマット適用済み
- [x] `bun run test` — 全513テスト通過
- [x] `bun run build` — Next.jsビルド成功
- [ ] ワスレ町→Route 1→草むらバトル（ボール5個・ポーション3個所持確認）
- [ ] メッセージ表示中にキー入力が漏れないこと
- [ ] ジム戦→大忘却イベント発火→同じマップに戻っても再発火しないこと
- [ ] ポケモンリーグで四天王4人+チャンピオンと順番に戦えること

🤖 Generated with [Claude Code](https://claude.com/claude-code)