### PR TITLE
feat: HUD・歩行アニメ・バーチャルパッド・レスポンシブ・A11y・カットシーン

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -75,6 +75,38 @@ body {
   }
 }
 
+/* モバイル: オーバーワールドビューポートスケーリング */
+@media (max-width: 520px) {
+  .overworld-viewport {
+    transform: scale(0.85);
+    transform-origin: center center;
+  }
+}
+
+@media (max-width: 400px) {
+  .overworld-viewport {
+    transform: scale(0.72);
+    transform-origin: center center;
+  }
+}
+
+/* モバイル: バトル画面レイアウト調整 */
+@media (max-width: 520px) {
+  .game-container {
+    font-size: 14px;
+  }
+}
+
+/* タッチデバイスでのテキスト選択防止 */
+@media (pointer: coarse) {
+  .game-container {
+    -webkit-user-select: none;
+    user-select: none;
+    -webkit-touch-callout: none;
+    touch-action: manipulation;
+  }
+}
+
 /* ─── RPGウィンドウフレーム ─── */
 
 .rpg-window {
@@ -213,6 +245,37 @@ body {
 }
 .animate-damage-shake {
   animation: damage-shake 0.3s ease-out;
+}
+.animate-grass-sway {
+  animation: grass-sway 0.4s ease-out;
+}
+.animate-water-shimmer {
+  animation: water-shimmer 3s ease-in-out infinite;
+}
+
+@keyframes grass-sway {
+  0% {
+    transform: scaleX(1);
+  }
+  25% {
+    transform: scaleX(0.92) skewX(3deg);
+  }
+  50% {
+    transform: scaleX(1.05) skewX(-2deg);
+  }
+  100% {
+    transform: scaleX(1) skewX(0);
+  }
+}
+
+@keyframes water-shimmer {
+  0%,
+  100% {
+    background-position: -200% -200%;
+  }
+  50% {
+    background-position: 200% 200%;
+  }
 }
 
 /* ─── HP バー グラデーション ─── */

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -1178,6 +1178,21 @@ export function Game() {
             onNpcInteract={handleNpcInteract}
             onMenuOpen={handleMenuOpen}
             onPositionChange={handlePositionChange}
+            leadMonster={
+              state.player?.partyState.party[0]
+                ? (() => {
+                    const m = state.player!.partyState.party[0];
+                    const sp = speciesResolver(m.speciesId);
+                    return {
+                      name: m.nickname ?? sp.name,
+                      currentHp: m.currentHp,
+                      maxHp: getMaxHp(m),
+                      level: m.level,
+                      speciesId: m.speciesId,
+                    };
+                  })()
+                : null
+            }
           />
           {renderOverlay()}
           {messageOverlay}

--- a/src/components/screens/BattleScreen.tsx
+++ b/src/components/screens/BattleScreen.tsx
@@ -143,6 +143,8 @@ export function BattleScreen({
       className="flex h-full w-full flex-col bg-[#1a1a2e]"
       onKeyDown={handleKeyDown}
       tabIndex={0}
+      role="main"
+      aria-label={`バトル: ${player.name} 対 ${opponent.name}`}
     >
       {/* バトルフィールド */}
       <div className="relative flex flex-1 flex-col justify-between px-6 py-4">

--- a/src/components/screens/MenuScreen.tsx
+++ b/src/components/screens/MenuScreen.tsx
@@ -73,8 +73,10 @@ export function MenuScreen({
       style={{ backgroundColor: "rgba(10, 10, 26, 0.6)" }}
       onKeyDown={handleKeyDown}
       tabIndex={0}
+      role="dialog"
+      aria-label="メインメニュー"
     >
-      <div className="rpg-window animate-fade-in w-60">
+      <div className="rpg-window animate-fade-in w-60" role="menu">
         {/* プレイヤー情報 */}
         <div className="border-b border-[#533483]/30 px-4 py-3">
           <p className="game-text-shadow font-[family-name:var(--font-dotgothic)] text-sm text-white">
@@ -95,6 +97,9 @@ export function MenuScreen({
               }`}
               onClick={() => handleSelect(i)}
               onMouseEnter={() => setSelectedIndex(i)}
+              role="menuitem"
+              aria-label={`${item.label}: ${item.description}`}
+              aria-current={i === selectedIndex ? "true" : undefined}
             >
               <span
                 className="w-4 text-center text-xs"

--- a/src/components/screens/OverworldScreen.tsx
+++ b/src/components/screens/OverworldScreen.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import type { MapDefinition } from "@/engine/map/map-data";
 import type { PlayerPosition, Direction } from "@/engine/map/player-movement";
 import { movePlayer, getFacingNpc } from "@/engine/map/player-movement";
@@ -12,10 +12,13 @@ import {
   NpcSprite,
   getNpcAppearance,
 } from "../ui/OverworldSprites";
+import { OverworldHUD, type HUDMonsterInfo } from "../ui/OverworldHUD";
+import { VirtualPad } from "../ui/VirtualPad";
 
 /**
  * オーバーワールド画面 (#28)
  * DOMベースのグリッドマップ表示 - ハイブリッドデザイン
+ * + HUD (#140), 歩行アニメ (#143), バーチャルパッド (#147), レスポンシブ (#146)
  */
 
 const TILE_SIZE = 32;
@@ -32,6 +35,8 @@ export interface OverworldScreenProps {
   onNpcInteract?: (npcId: string) => void;
   onMenuOpen?: () => void;
   onPositionChange?: (x: number, y: number, direction: Direction) => void;
+  /** 先頭モンスター情報（HUD表示用） */
+  leadMonster?: HUDMonsterInfo | null;
 }
 
 const DIRECTION_KEYS: Record<string, Direction> = {
@@ -55,10 +60,16 @@ export function OverworldScreen({
   onNpcInteract,
   onMenuOpen,
   onPositionChange,
+  leadMonster,
 }: OverworldScreenProps) {
   const [position, setPosition] = useState<PlayerPosition>(initialPosition);
   const [blockedMsg, setBlockedMsg] = useState<string[] | null>(null);
   const [showMapName, setShowMapName] = useState(true);
+  /** 歩行アニメーション: 0=静止, 1=フレーム1, 2=フレーム2 */
+  const [walkFrame, setWalkFrame] = useState(0);
+  const walkTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  /** 草揺れエフェクト用の座標 */
+  const [grassSwayTile, setGrassSwayTile] = useState<{ x: number; y: number } | null>(null);
 
   // マップ名をフェードアウト
   useEffect(() => {
@@ -70,6 +81,13 @@ export function OverworldScreen({
     };
   }, [map.id]);
 
+  // 歩行フレームリセット用タイマーのクリーンアップ
+  useEffect(() => {
+    return () => {
+      if (walkTimerRef.current) clearTimeout(walkTimerRef.current);
+    };
+  }, []);
+
   const handleMove = useCallback(
     (direction: Direction) => {
       if (blockedMsg) return;
@@ -77,9 +95,22 @@ export function OverworldScreen({
       const result = movePlayer(position, direction, map, storyFlags);
       setPosition(result.position);
 
-      // 親に位置を通知（バトル復帰時に正しい位置を復元するため）
+      // 歩行アニメーション
       if (result.moved) {
+        setWalkFrame((prev) => (prev === 1 ? 2 : 1));
+        if (walkTimerRef.current) clearTimeout(walkTimerRef.current);
+        walkTimerRef.current = setTimeout(() => setWalkFrame(0), 200);
+
         onPositionChange?.(result.position.x, result.position.y, result.position.direction);
+
+        // 草タイルを踏んだら揺れエフェクト
+        const tile = map.tiles[result.position.y]?.[result.position.x];
+        if (tile === "grass") {
+          setGrassSwayTile({ x: result.position.x, y: result.position.y });
+          setTimeout(() => setGrassSwayTile(null), 400);
+        }
+      } else {
+        // 移動失敗時は向き変更のみ（アニメなし）
       }
 
       if (result.blockedMessage) {
@@ -142,6 +173,9 @@ export function OverworldScreen({
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [handleMove, handleInteract, onMenuOpen, inputBlocked]);
 
+  // NPC「!」ヒント判定
+  const facingNpcId = getFacingNpc(position, map);
+
   const offsetX = Math.max(
     0,
     Math.min(position.x - Math.floor(VIEWPORT_TILES_X / 2), map.width - VIEWPORT_TILES_X),
@@ -157,7 +191,7 @@ export function OverworldScreen({
   return (
     <div className="flex h-full w-full items-center justify-center bg-[#1a1a2e]">
       <div
-        className="relative overflow-hidden"
+        className="overworld-viewport relative overflow-hidden"
         style={{
           width: visibleTilesX * TILE_SIZE,
           height: visibleTilesY * TILE_SIZE,
@@ -171,11 +205,13 @@ export function OverworldScreen({
             const mapY = vy + offsetY;
             if (mapX >= map.width || mapY >= map.height) return null;
             const tileType = map.tiles[mapY]?.[mapX] ?? "ground";
+            const isGrassSway =
+              grassSwayTile && grassSwayTile.x === mapX && grassSwayTile.y === mapY;
 
             return (
               <div
                 key={`${mapX}-${mapY}`}
-                className="absolute pixel-perfect"
+                className={`absolute pixel-perfect${isGrassSway ? " animate-grass-sway" : ""}`}
                 style={{
                   left: vx * TILE_SIZE,
                   top: vy * TILE_SIZE,
@@ -183,6 +219,34 @@ export function OverworldScreen({
                   height: TILE_SIZE,
                   background: getTileBackground(tileType),
                   backgroundSize: "100% 100%",
+                }}
+              />
+            );
+          }),
+        )}
+
+        {/* 水タイルアニメーション */}
+        {Array.from({ length: visibleTilesY }, (_, vy) =>
+          Array.from({ length: visibleTilesX }, (_, vx) => {
+            const mapX = vx + offsetX;
+            const mapY = vy + offsetY;
+            if (mapX >= map.width || mapY >= map.height) return null;
+            const tileType = map.tiles[mapY]?.[mapX];
+            if (tileType !== "water") return null;
+
+            return (
+              <div
+                key={`water-${mapX}-${mapY}`}
+                className="pointer-events-none absolute pixel-perfect animate-water-shimmer"
+                style={{
+                  left: vx * TILE_SIZE,
+                  top: vy * TILE_SIZE,
+                  width: TILE_SIZE,
+                  height: TILE_SIZE,
+                  background:
+                    "linear-gradient(135deg, transparent 40%, rgba(255,255,255,0.12) 50%, transparent 60%)",
+                  backgroundSize: "200% 200%",
+                  animationDelay: `${((mapX + mapY) % 4) * 0.5}s`,
                 }}
               />
             );
@@ -223,12 +287,20 @@ export function OverworldScreen({
             height: TILE_SIZE,
           }}
         >
-          <PlayerSprite direction={position.direction} size={28} />
+          <PlayerSprite direction={position.direction} size={28} walkFrame={walkFrame} />
         </div>
+
+        {/* HUD */}
+        <OverworldHUD
+          map={map}
+          position={position}
+          leadMonster={leadMonster}
+          facingNpc={!!facingNpcId}
+        />
 
         {/* マップ名ポップアップ */}
         <div
-          className="absolute left-1/2 top-3 -translate-x-1/2 rounded-md px-4 py-1.5 transition-all duration-500"
+          className="absolute left-1/2 top-8 z-20 -translate-x-1/2 rounded-md px-4 py-1.5 transition-all duration-500"
           style={{
             background:
               "linear-gradient(90deg, transparent, rgba(22,33,62,0.95), rgba(22,33,62,0.95), transparent)",
@@ -242,6 +314,15 @@ export function OverworldScreen({
           </span>
         </div>
       </div>
+
+      {/* バーチャルパッド（モバイル用） */}
+      <VirtualPad
+        onDirection={(dir) => !inputBlocked && handleMove(dir)}
+        onConfirm={() => !inputBlocked && handleInteract()}
+        onCancel={() => {}}
+        onMenu={() => !inputBlocked && onMenuOpen?.()}
+        disabled={inputBlocked}
+      />
 
       {/* ブロックメッセージ */}
       {blockedMsg && <MessageWindow messages={blockedMsg} onComplete={() => setBlockedMsg(null)} />}

--- a/src/components/screens/TitleScreen.tsx
+++ b/src/components/screens/TitleScreen.tsx
@@ -64,6 +64,8 @@ export function TitleScreen({ onNewGame, onContinue, hasSaveData = false }: Titl
       className="relative flex h-full w-full flex-col items-center justify-center overflow-hidden bg-[#1a1a2e]"
       onKeyDown={handleKeyDown}
       tabIndex={0}
+      role="main"
+      aria-label="Monster Chronicle タイトル画面"
     >
       {/* 背景エフェクト */}
       <div className="pointer-events-none absolute inset-0">

--- a/src/components/ui/CutsceneOverlay.tsx
+++ b/src/components/ui/CutsceneOverlay.tsx
@@ -1,0 +1,360 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+/**
+ * カットシーン演出 (#153)
+ * バッジ取得、殿堂入り、スタッフロール
+ */
+
+// ─── バッジ取得アニメーション ─────────────────────
+
+export interface BadgeGetProps {
+  badgeName: string;
+  gymLeaderName: string;
+  badgeNumber: number;
+  onComplete: () => void;
+}
+
+export function BadgeGetAnimation({
+  badgeName,
+  gymLeaderName,
+  badgeNumber,
+  onComplete,
+}: BadgeGetProps) {
+  const [phase, setPhase] = useState(0);
+
+  useEffect(() => {
+    const t1 = setTimeout(() => setPhase(1), 100);
+    const t2 = setTimeout(() => setPhase(2), 800);
+    const t3 = setTimeout(() => setPhase(3), 2000);
+    const t4 = setTimeout(() => onComplete(), 4000);
+    return () => {
+      clearTimeout(t1);
+      clearTimeout(t2);
+      clearTimeout(t3);
+      clearTimeout(t4);
+    };
+  }, [onComplete]);
+
+  // バッジの色をジムナンバーで変化
+  const badgeColors = [
+    "#B8B8D0",
+    "#e94560",
+    "#5b9bd5",
+    "#5cb85c",
+    "#F8D030",
+    "#533483",
+    "#ff6b81",
+    "#F0C040",
+  ];
+  const color = badgeColors[(badgeNumber - 1) % badgeColors.length];
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex flex-col items-center justify-center"
+      style={{ backgroundColor: "rgba(10, 10, 26, 0.95)" }}
+      role="alert"
+      aria-label={`${badgeName}を手に入れた！`}
+    >
+      {/* バッジSVG */}
+      <div
+        className="mb-6 transition-all duration-700"
+        style={{
+          opacity: phase >= 1 ? 1 : 0,
+          transform: phase >= 1 ? "scale(1) rotate(0deg)" : "scale(0.3) rotate(-180deg)",
+        }}
+      >
+        <svg viewBox="0 0 64 64" width={120} height={120}>
+          {/* 光芒 */}
+          {phase >= 2 &&
+            Array.from({ length: 8 }).map((_, i) => (
+              <line
+                key={i}
+                x1="32"
+                y1="32"
+                x2={32 + Math.cos((i * Math.PI) / 4) * 30}
+                y2={32 + Math.sin((i * Math.PI) / 4) * 30}
+                stroke={color}
+                strokeWidth="1"
+                opacity="0.5"
+              />
+            ))}
+          {/* バッジ本体（八角形） */}
+          <polygon
+            points="32,6 44,12 50,24 50,40 44,52 32,58 20,52 14,40 14,24 20,12"
+            fill={color}
+            stroke="#fff"
+            strokeWidth="1.5"
+          />
+          {/* 内部装飾 */}
+          <polygon
+            points="32,14 40,18 44,28 44,36 40,46 32,50 24,46 20,36 20,28 24,18"
+            fill="none"
+            stroke="#fff"
+            strokeWidth="0.8"
+            opacity="0.4"
+          />
+          {/* 中央の星 */}
+          <polygon
+            points="32,20 35,28 44,28 37,33 39,42 32,37 25,42 27,33 20,28 29,28"
+            fill="#fff"
+            opacity="0.6"
+          />
+          {/* ナンバー */}
+          <text
+            x="32"
+            y="36"
+            textAnchor="middle"
+            fill="#fff"
+            fontSize="10"
+            fontFamily="'Press Start 2P', monospace"
+          >
+            {badgeNumber}
+          </text>
+        </svg>
+      </div>
+
+      {/* テキスト */}
+      <p
+        className="game-text-shadow mb-2 font-[family-name:var(--font-dotgothic)] text-xl text-white transition-all duration-500"
+        style={{
+          opacity: phase >= 2 ? 1 : 0,
+          transform: phase >= 2 ? "translateY(0)" : "translateY(10px)",
+        }}
+      >
+        {badgeName}を手に入れた！
+      </p>
+      <p
+        className="font-[family-name:var(--font-dotgothic)] text-sm text-gray-400 transition-all duration-500"
+        style={{
+          opacity: phase >= 3 ? 1 : 0,
+        }}
+      >
+        {gymLeaderName}を倒した！
+      </p>
+    </div>
+  );
+}
+
+// ─── 殿堂入り演出 ─────────────────────────────
+
+export interface HallOfFameEntry {
+  speciesId: string;
+  name: string;
+  level: number;
+}
+
+export interface HallOfFameProps {
+  playerName: string;
+  party: HallOfFameEntry[];
+  onComplete: () => void;
+}
+
+export function HallOfFameScreen({ playerName, party, onComplete }: HallOfFameProps) {
+  const [phase, setPhase] = useState(0);
+  const [shownIndex, setShownIndex] = useState(-1);
+
+  useEffect(() => {
+    const partyLen = party.length;
+    const t0 = setTimeout(() => setPhase(1), 500);
+    // 各モンスターを順番に表示
+    const timers = party.map((_, i) => setTimeout(() => setShownIndex(i), 1500 + i * 800));
+    const tFinal = setTimeout(() => setPhase(2), 1500 + partyLen * 800 + 500);
+    const tEnd = setTimeout(() => onComplete(), 1500 + partyLen * 800 + 3000);
+    return () => {
+      clearTimeout(t0);
+      timers.forEach(clearTimeout);
+      clearTimeout(tFinal);
+      clearTimeout(tEnd);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [party.length, onComplete]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex flex-col items-center justify-center"
+      style={{
+        background: "radial-gradient(ellipse at 50% 30%, #1a1a4e, #0a0a1a)",
+      }}
+      role="alert"
+      aria-label="殿堂入り"
+    >
+      {/* タイトル */}
+      <h1
+        className="game-text-shadow mb-8 text-center font-[family-name:var(--font-pressstart)] text-xl tracking-wider text-[#F8D030] transition-all duration-1000"
+        style={{
+          opacity: phase >= 1 ? 1 : 0,
+          transform: phase >= 1 ? "translateY(0)" : "translateY(-20px)",
+          textShadow: "0 0 20px rgba(248,208,48,0.5), 1px 1px 0 rgba(0,0,0,0.8)",
+        }}
+      >
+        HALL OF FAME
+      </h1>
+
+      {/* パーティ一覧 */}
+      <div className="grid grid-cols-3 gap-4">
+        {party.map((member, i) => (
+          <div
+            key={i}
+            className="flex flex-col items-center transition-all duration-500"
+            style={{
+              opacity: i <= shownIndex ? 1 : 0,
+              transform: i <= shownIndex ? "scale(1)" : "scale(0.5)",
+            }}
+          >
+            {/* モンスターシルエット→カラー化 */}
+            <div
+              className="mb-2 flex h-16 w-16 items-center justify-center rounded-lg"
+              style={{
+                background: "radial-gradient(ellipse, rgba(83,52,131,0.4), transparent)",
+                boxShadow: "0 0 15px rgba(233,69,96,0.2)",
+              }}
+            >
+              <span className="font-[family-name:var(--font-pressstart)] text-2xl text-[#e94560]">
+                ★
+              </span>
+            </div>
+            <p className="game-text-shadow font-[family-name:var(--font-dotgothic)] text-sm text-white">
+              {member.name}
+            </p>
+            <p className="font-[family-name:var(--font-dotgothic)] text-[10px] text-gray-500">
+              Lv.{member.level}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      {/* プレイヤー名 */}
+      <p
+        className="game-text-shadow mt-8 font-[family-name:var(--font-dotgothic)] text-lg text-white transition-all duration-700"
+        style={{
+          opacity: phase >= 2 ? 1 : 0,
+        }}
+      >
+        トレーナー {playerName} と仲間たち
+      </p>
+      <p
+        className="mt-2 font-[family-name:var(--font-dotgothic)] text-sm text-[#F8D030] transition-all duration-700"
+        style={{
+          opacity: phase >= 2 ? 1 : 0,
+        }}
+      >
+        おめでとう！
+      </p>
+    </div>
+  );
+}
+
+// ─── スタッフロール ─────────────────────────────
+
+export interface StaffRollProps {
+  onComplete: () => void;
+}
+
+const CREDITS = [
+  { role: "Director", name: "Monster Chronicle Team" },
+  { role: "Game Design", name: "Monster Chronicle Team" },
+  { role: "Programming", name: "AI-Assisted Development" },
+  { role: "Art Direction", name: "Pixel Art Generator" },
+  { role: "Music", name: "Chiptune Synthesizer" },
+  { role: "Story", name: "Monster Chronicle Team" },
+  { role: "", name: "" },
+  { role: "Special Thanks", name: "You, the Player!" },
+  { role: "", name: "" },
+  { role: "", name: "MONSTER CHRONICLE" },
+  { role: "", name: "― FIN ―" },
+];
+
+export function StaffRoll({ onComplete }: StaffRollProps) {
+  const [scrollY, setScrollY] = useState(0);
+  const totalHeight = CREDITS.length * 80 + 400;
+
+  useEffect(() => {
+    const startTime = Date.now();
+    const speed = 40; // px per second
+    let frameId: number;
+
+    const animate = () => {
+      const elapsed = (Date.now() - startTime) / 1000;
+      const y = elapsed * speed;
+      setScrollY(y);
+
+      if (y < totalHeight) {
+        frameId = requestAnimationFrame(animate);
+      } else {
+        onComplete();
+      }
+    };
+
+    frameId = requestAnimationFrame(animate);
+    return () => cancelAnimationFrame(frameId);
+  }, [totalHeight, onComplete]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 overflow-hidden"
+      style={{ backgroundColor: "#0a0a1a" }}
+      role="region"
+      aria-label="スタッフロール"
+    >
+      {/* 星空背景 */}
+      <div className="absolute inset-0">
+        {Array.from({ length: 30 }).map((_, i) => (
+          <div
+            key={i}
+            className="absolute rounded-full bg-white"
+            style={{
+              width: `${1 + (i % 3)}px`,
+              height: `${1 + (i % 3)}px`,
+              left: `${(i * 13 + 7) % 100}%`,
+              top: `${(i * 17 + 3) % 100}%`,
+              opacity: 0.3 + (i % 5) * 0.1,
+              animation: `blink ${2 + (i % 3)}s ease-in-out infinite`,
+              animationDelay: `${i * 0.2}s`,
+            }}
+          />
+        ))}
+      </div>
+
+      {/* スクロールするクレジット */}
+      <div
+        className="absolute left-0 right-0 flex flex-col items-center"
+        style={{
+          top: `calc(100% - ${scrollY}px)`,
+        }}
+      >
+        {CREDITS.map((credit, i) => (
+          <div key={i} className="mb-10 text-center" style={{ minHeight: 60 }}>
+            {credit.role && (
+              <p className="mb-1 font-[family-name:var(--font-dotgothic)] text-xs tracking-widest text-[#533483]">
+                {credit.role}
+              </p>
+            )}
+            <p
+              className="game-text-shadow font-[family-name:var(--font-dotgothic)] text-lg text-white"
+              style={
+                credit.name === "― FIN ―"
+                  ? {
+                      fontFamily: "var(--font-pressstart)",
+                      color: "#F8D030",
+                      textShadow: "0 0 15px rgba(248,208,48,0.4)",
+                    }
+                  : credit.name === "MONSTER CHRONICLE"
+                    ? {
+                        fontFamily: "var(--font-pressstart)",
+                        fontSize: "1.5rem",
+                        color: "#e94560",
+                        textShadow: "0 0 20px rgba(233,69,96,0.5)",
+                      }
+                    : undefined
+              }
+            >
+              {credit.name}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/OverworldHUD.tsx
+++ b/src/components/ui/OverworldHUD.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { HpBar } from "./HpBar";
+import type { MapDefinition } from "@/engine/map/map-data";
+import type { PlayerPosition, Direction } from "@/engine/map/player-movement";
+
+/**
+ * オーバーワールドHUD (#140)
+ * ミニマップ、先頭モンスターHP、操作ガイド、NPC「!」マーク
+ */
+
+export interface HUDMonsterInfo {
+  name: string;
+  currentHp: number;
+  maxHp: number;
+  level: number;
+  speciesId: string;
+}
+
+export interface OverworldHUDProps {
+  map: MapDefinition;
+  position: PlayerPosition;
+  leadMonster?: HUDMonsterInfo | null;
+  facingNpc?: boolean;
+  showControls?: boolean;
+}
+
+/** ミニマップ: マップ全体の縮小表示 + プレイヤー位置 */
+function MiniMap({ map, position }: { map: MapDefinition; position: PlayerPosition }) {
+  const scale = Math.min(48 / map.width, 48 / map.height);
+  const w = Math.round(map.width * scale);
+  const h = Math.round(map.height * scale);
+
+  return (
+    <div
+      className="rounded border border-[#533483]/60 bg-[#16213e]/90"
+      style={{ width: w + 8, height: h + 8, padding: 4 }}
+    >
+      <svg viewBox={`0 0 ${map.width} ${map.height}`} width={w} height={h}>
+        {/* タイル概要 */}
+        {Array.from({ length: map.height }, (_, y) =>
+          Array.from({ length: map.width }, (_, x) => {
+            const tile = map.tiles[y]?.[x] ?? "ground";
+            let fill = "#8a7e5e";
+            if (tile === "wall") fill = "#4a4a5a";
+            else if (tile === "grass") fill = "#4a9e4a";
+            else if (tile === "water") fill = "#4a8ec4";
+            else if (tile === "door") fill = "#8b5e3c";
+            return <rect key={`${x}-${y}`} x={x} y={y} width={1} height={1} fill={fill} />;
+          }),
+        )}
+        {/* NPC位置 */}
+        {map.npcs.map((npc) => (
+          <rect
+            key={npc.id}
+            x={npc.x}
+            y={npc.y}
+            width={1}
+            height={1}
+            fill="#e94560"
+            opacity={0.8}
+          />
+        ))}
+        {/* プレイヤー位置 */}
+        <rect
+          x={position.x - 0.5}
+          y={position.y - 0.5}
+          width={2}
+          height={2}
+          fill="#fff"
+          opacity={0.9}
+        />
+      </svg>
+    </div>
+  );
+}
+
+/** 先頭モンスターHP表示 */
+function LeadMonsterBar({ monster }: { monster: HUDMonsterInfo }) {
+  return (
+    <div className="rounded border border-[#533483]/60 bg-[#16213e]/90 px-2 py-1">
+      <div className="flex items-center gap-1.5">
+        <span className="font-[family-name:var(--font-dotgothic)] text-[10px] text-white">
+          {monster.name}
+        </span>
+        <span className="font-[family-name:var(--font-dotgothic)] text-[8px] text-gray-500">
+          Lv.{monster.level}
+        </span>
+      </div>
+      <HpBar
+        current={monster.currentHp}
+        max={monster.maxHp}
+        className="mt-0.5 w-20"
+        showNumbers={false}
+      />
+    </div>
+  );
+}
+
+/** NPC会話ヒント「!」 */
+function NpcHint({ direction }: { direction: Direction }) {
+  const offsets: Record<Direction, { x: number; y: number }> = {
+    up: { x: 0, y: -20 },
+    down: { x: 0, y: 20 },
+    left: { x: -20, y: 0 },
+    right: { x: 20, y: 0 },
+  };
+  const { x, y } = offsets[direction];
+  return (
+    <div
+      className="pointer-events-none absolute"
+      style={{
+        left: `calc(50% + ${x}px)`,
+        top: `calc(50% + ${y}px)`,
+        transform: "translate(-50%, -50%)",
+      }}
+    >
+      <span
+        className="font-[family-name:var(--font-pressstart)] text-xl text-[#F8D030]"
+        style={{
+          textShadow: "0 0 8px rgba(248,208,48,0.6), 1px 1px 0 rgba(0,0,0,0.8)",
+          animation: "float 0.8s ease-in-out infinite",
+        }}
+      >
+        !
+      </span>
+    </div>
+  );
+}
+
+/** 操作ガイド（PC用） */
+function ControlGuide() {
+  return (
+    <div className="rounded border border-[#533483]/40 bg-[#16213e]/80 px-2 py-1">
+      <div className="flex gap-2 font-[family-name:var(--font-dotgothic)] text-[8px] text-gray-500">
+        <span>↑↓←→: 移動</span>
+        <span>Z: 話す</span>
+        <span>X: メニュー</span>
+      </div>
+    </div>
+  );
+}
+
+export function OverworldHUD({
+  map,
+  position,
+  leadMonster,
+  facingNpc = false,
+  showControls = true,
+}: OverworldHUDProps) {
+  return (
+    <>
+      {/* 左上: ミニマップ */}
+      <div className="absolute left-1 top-1 z-20">
+        <MiniMap map={map} position={position} />
+      </div>
+
+      {/* 右上: 先頭モンスターHP */}
+      {leadMonster && (
+        <div className="absolute right-1 top-1 z-20">
+          <LeadMonsterBar monster={leadMonster} />
+        </div>
+      )}
+
+      {/* NPC「!」ヒント */}
+      {facingNpc && <NpcHint direction={position.direction} />}
+
+      {/* 右下: 操作ガイド（PC時のみ） */}
+      {showControls && (
+        <div className="absolute bottom-1 right-1 z-20 hidden sm:block">
+          <ControlGuide />
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/ui/OverworldSprites.tsx
+++ b/src/components/ui/OverworldSprites.tsx
@@ -102,11 +102,21 @@ export function getTileBackground(tileType: TileType): string {
 
 // ─── プレイヤースプライト ─────────────────────────────
 
-/** 16x16ピクセルアートのプレイヤーキャラ（方向別） */
-export function PlayerSprite({ direction, size = 28 }: { direction: Direction; size?: number }) {
+/** 16x16ピクセルアートのプレイヤーキャラ（方向別・歩行フレーム対応） */
+export function PlayerSprite({
+  direction,
+  size = 28,
+  walkFrame = 0,
+}: {
+  direction: Direction;
+  size?: number;
+  /** 歩行フレーム 0=静止, 1=右足, 2=左足 */
+  walkFrame?: number;
+}) {
+  const frame = walkFrame > 0 ? PLAYER_WALK_FRAMES[direction]?.[walkFrame - 1] : null;
   return (
     <svg viewBox="0 0 16 16" width={size} height={size} style={{ imageRendering: "pixelated" }}>
-      {PLAYER_SVG_PATHS[direction]}
+      {frame ?? PLAYER_SVG_PATHS[direction]}
     </svg>
   );
 }
@@ -203,6 +213,142 @@ const PLAYER_SVG_PATHS: Record<Direction, React.ReactNode> = {
       <rect x="12" y="9" width="1" height="3" fill="#fdd" />
     </>
   ),
+};
+
+/** 歩行アニメーション（2フレーム: 右足前 / 左足前） */
+const PLAYER_WALK_FRAMES: Record<Direction, [React.ReactNode, React.ReactNode]> = {
+  down: [
+    // フレーム1: 右足前
+    <>
+      <rect x="5" y="1" width="6" height="3" fill="#e94560" />
+      <rect x="4" y="2" width="1" height="2" fill="#e94560" />
+      <rect x="11" y="2" width="1" height="2" fill="#e94560" />
+      <rect x="5" y="0" width="6" height="1" fill="#c83050" />
+      <rect x="5" y="4" width="6" height="4" fill="#fdd" />
+      <rect x="6" y="5" width="1" height="1" fill="#333" />
+      <rect x="9" y="5" width="1" height="1" fill="#333" />
+      <rect x="7" y="7" width="2" height="1" fill="#d9a" />
+      <rect x="4" y="8" width="8" height="4" fill="#4477cc" />
+      <rect x="6" y="8" width="4" height="1" fill="#5588dd" />
+      <rect x="7" y="9" width="2" height="2" fill="#fdd" />
+      <rect x="4" y="12" width="2" height="2" fill="#445" />
+      <rect x="10" y="12" width="2" height="2" fill="#445" />
+      <rect x="3" y="9" width="1" height="3" fill="#fdd" />
+      <rect x="12" y="9" width="1" height="3" fill="#fdd" />
+    </>,
+    // フレーム2: 左足前
+    <>
+      <rect x="5" y="1" width="6" height="3" fill="#e94560" />
+      <rect x="4" y="2" width="1" height="2" fill="#e94560" />
+      <rect x="11" y="2" width="1" height="2" fill="#e94560" />
+      <rect x="5" y="0" width="6" height="1" fill="#c83050" />
+      <rect x="5" y="4" width="6" height="4" fill="#fdd" />
+      <rect x="6" y="5" width="1" height="1" fill="#333" />
+      <rect x="9" y="5" width="1" height="1" fill="#333" />
+      <rect x="7" y="7" width="2" height="1" fill="#d9a" />
+      <rect x="4" y="8" width="8" height="4" fill="#4477cc" />
+      <rect x="6" y="8" width="4" height="1" fill="#5588dd" />
+      <rect x="7" y="9" width="2" height="2" fill="#fdd" />
+      <rect x="6" y="12" width="2" height="2" fill="#445" />
+      <rect x="8" y="12" width="2" height="2" fill="#445" />
+      <rect x="3" y="9" width="1" height="3" fill="#fdd" />
+      <rect x="12" y="9" width="1" height="3" fill="#fdd" />
+    </>,
+  ],
+  up: [
+    <>
+      <rect x="5" y="1" width="6" height="3" fill="#e94560" />
+      <rect x="4" y="2" width="1" height="2" fill="#e94560" />
+      <rect x="11" y="2" width="1" height="2" fill="#e94560" />
+      <rect x="5" y="0" width="6" height="1" fill="#c83050" />
+      <rect x="5" y="4" width="6" height="4" fill="#654" />
+      <rect x="5" y="4" width="6" height="1" fill="#543" />
+      <rect x="4" y="8" width="8" height="4" fill="#4477cc" />
+      <rect x="6" y="8" width="4" height="1" fill="#3366bb" />
+      <rect x="4" y="12" width="2" height="2" fill="#445" />
+      <rect x="10" y="12" width="2" height="2" fill="#445" />
+      <rect x="3" y="9" width="1" height="3" fill="#fdd" />
+      <rect x="12" y="9" width="1" height="3" fill="#fdd" />
+    </>,
+    <>
+      <rect x="5" y="1" width="6" height="3" fill="#e94560" />
+      <rect x="4" y="2" width="1" height="2" fill="#e94560" />
+      <rect x="11" y="2" width="1" height="2" fill="#e94560" />
+      <rect x="5" y="0" width="6" height="1" fill="#c83050" />
+      <rect x="5" y="4" width="6" height="4" fill="#654" />
+      <rect x="5" y="4" width="6" height="1" fill="#543" />
+      <rect x="4" y="8" width="8" height="4" fill="#4477cc" />
+      <rect x="6" y="8" width="4" height="1" fill="#3366bb" />
+      <rect x="6" y="12" width="2" height="2" fill="#445" />
+      <rect x="8" y="12" width="2" height="2" fill="#445" />
+      <rect x="3" y="9" width="1" height="3" fill="#fdd" />
+      <rect x="12" y="9" width="1" height="3" fill="#fdd" />
+    </>,
+  ],
+  left: [
+    <>
+      <rect x="4" y="1" width="6" height="3" fill="#e94560" />
+      <rect x="3" y="2" width="1" height="2" fill="#e94560" />
+      <rect x="2" y="2" width="1" height="1" fill="#c83050" />
+      <rect x="4" y="0" width="6" height="1" fill="#c83050" />
+      <rect x="4" y="4" width="6" height="4" fill="#fdd" />
+      <rect x="5" y="5" width="1" height="1" fill="#333" />
+      <rect x="4" y="7" width="2" height="1" fill="#d9a" />
+      <rect x="9" y="4" width="1" height="3" fill="#654" />
+      <rect x="4" y="8" width="7" height="4" fill="#4477cc" />
+      <rect x="5" y="8" width="3" height="1" fill="#5588dd" />
+      <rect x="4" y="12" width="2" height="2" fill="#445" />
+      <rect x="8" y="12" width="2" height="3" fill="#445" />
+      <rect x="3" y="9" width="1" height="3" fill="#fdd" />
+    </>,
+    <>
+      <rect x="4" y="1" width="6" height="3" fill="#e94560" />
+      <rect x="3" y="2" width="1" height="2" fill="#e94560" />
+      <rect x="2" y="2" width="1" height="1" fill="#c83050" />
+      <rect x="4" y="0" width="6" height="1" fill="#c83050" />
+      <rect x="4" y="4" width="6" height="4" fill="#fdd" />
+      <rect x="5" y="5" width="1" height="1" fill="#333" />
+      <rect x="4" y="7" width="2" height="1" fill="#d9a" />
+      <rect x="9" y="4" width="1" height="3" fill="#654" />
+      <rect x="4" y="8" width="7" height="4" fill="#4477cc" />
+      <rect x="5" y="8" width="3" height="1" fill="#5588dd" />
+      <rect x="6" y="12" width="2" height="3" fill="#445" />
+      <rect x="8" y="12" width="2" height="2" fill="#445" />
+      <rect x="3" y="9" width="1" height="3" fill="#fdd" />
+    </>,
+  ],
+  right: [
+    <>
+      <rect x="6" y="1" width="6" height="3" fill="#e94560" />
+      <rect x="12" y="2" width="1" height="2" fill="#e94560" />
+      <rect x="13" y="2" width="1" height="1" fill="#c83050" />
+      <rect x="6" y="0" width="6" height="1" fill="#c83050" />
+      <rect x="6" y="4" width="6" height="4" fill="#fdd" />
+      <rect x="10" y="5" width="1" height="1" fill="#333" />
+      <rect x="10" y="7" width="2" height="1" fill="#d9a" />
+      <rect x="6" y="4" width="1" height="3" fill="#654" />
+      <rect x="5" y="8" width="7" height="4" fill="#4477cc" />
+      <rect x="8" y="8" width="3" height="1" fill="#5588dd" />
+      <rect x="6" y="12" width="2" height="3" fill="#445" />
+      <rect x="10" y="12" width="2" height="2" fill="#445" />
+      <rect x="12" y="9" width="1" height="3" fill="#fdd" />
+    </>,
+    <>
+      <rect x="6" y="1" width="6" height="3" fill="#e94560" />
+      <rect x="12" y="2" width="1" height="2" fill="#e94560" />
+      <rect x="13" y="2" width="1" height="1" fill="#c83050" />
+      <rect x="6" y="0" width="6" height="1" fill="#c83050" />
+      <rect x="6" y="4" width="6" height="4" fill="#fdd" />
+      <rect x="10" y="5" width="1" height="1" fill="#333" />
+      <rect x="10" y="7" width="2" height="1" fill="#d9a" />
+      <rect x="6" y="4" width="1" height="3" fill="#654" />
+      <rect x="5" y="8" width="7" height="4" fill="#4477cc" />
+      <rect x="8" y="8" width="3" height="1" fill="#5588dd" />
+      <rect x="6" y="12" width="2" height="2" fill="#445" />
+      <rect x="10" y="12" width="2" height="3" fill="#445" />
+      <rect x="12" y="9" width="1" height="3" fill="#fdd" />
+    </>,
+  ],
 };
 
 // ─── NPCスプライト ─────────────────────────────────

--- a/src/components/ui/VirtualPad.tsx
+++ b/src/components/ui/VirtualPad.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useCallback, useRef } from "react";
+import type { Direction } from "@/engine/map/player-movement";
+
+/**
+ * バーチャルパッド (#147)
+ * タッチデバイス用の方向パッド + A/B/メニューボタン
+ */
+
+export interface VirtualPadProps {
+  onDirection: (direction: Direction) => void;
+  onConfirm: () => void;
+  onCancel: () => void;
+  onMenu: () => void;
+  disabled?: boolean;
+}
+
+/** D-Pad方向ボタン */
+function DPad({
+  onDirection,
+  disabled,
+}: {
+  onDirection: (d: Direction) => void;
+  disabled?: boolean;
+}) {
+  const repeatRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const startRepeat = useCallback(
+    (dir: Direction) => {
+      if (disabled) return;
+      onDirection(dir);
+      repeatRef.current = setInterval(() => onDirection(dir), 200);
+    },
+    [onDirection, disabled],
+  );
+
+  const stopRepeat = useCallback(() => {
+    if (repeatRef.current) {
+      clearInterval(repeatRef.current);
+      repeatRef.current = null;
+    }
+  }, []);
+
+  const btnClass =
+    "flex items-center justify-center bg-[#16213e]/90 border border-[#533483]/50 active:bg-[#533483]/60 transition-colors select-none touch-none";
+
+  return (
+    <div className="grid grid-cols-3 grid-rows-3 gap-0.5" style={{ width: 96, height: 96 }}>
+      <div />
+      <button
+        className={`${btnClass} rounded-t-lg`}
+        onTouchStart={() => startRepeat("up")}
+        onTouchEnd={stopRepeat}
+        onTouchCancel={stopRepeat}
+        onMouseDown={() => startRepeat("up")}
+        onMouseUp={stopRepeat}
+        onMouseLeave={stopRepeat}
+        aria-label="上に移動"
+      >
+        <span className="text-sm text-white/80">▲</span>
+      </button>
+      <div />
+      <button
+        className={`${btnClass} rounded-l-lg`}
+        onTouchStart={() => startRepeat("left")}
+        onTouchEnd={stopRepeat}
+        onTouchCancel={stopRepeat}
+        onMouseDown={() => startRepeat("left")}
+        onMouseUp={stopRepeat}
+        onMouseLeave={stopRepeat}
+        aria-label="左に移動"
+      >
+        <span className="text-sm text-white/80">◀</span>
+      </button>
+      <div className="flex items-center justify-center rounded bg-[#0f3460]/60 border border-[#533483]/30">
+        <span className="text-[8px] text-gray-600">+</span>
+      </div>
+      <button
+        className={`${btnClass} rounded-r-lg`}
+        onTouchStart={() => startRepeat("right")}
+        onTouchEnd={stopRepeat}
+        onTouchCancel={stopRepeat}
+        onMouseDown={() => startRepeat("right")}
+        onMouseUp={stopRepeat}
+        onMouseLeave={stopRepeat}
+        aria-label="右に移動"
+      >
+        <span className="text-sm text-white/80">▶</span>
+      </button>
+      <div />
+      <button
+        className={`${btnClass} rounded-b-lg`}
+        onTouchStart={() => startRepeat("down")}
+        onTouchEnd={stopRepeat}
+        onTouchCancel={stopRepeat}
+        onMouseDown={() => startRepeat("down")}
+        onMouseUp={stopRepeat}
+        onMouseLeave={stopRepeat}
+        aria-label="下に移動"
+      >
+        <span className="text-sm text-white/80">▼</span>
+      </button>
+      <div />
+    </div>
+  );
+}
+
+/** アクションボタン（A/B） */
+function ActionButtons({
+  onConfirm,
+  onCancel,
+  disabled,
+}: {
+  onConfirm: () => void;
+  onCancel: () => void;
+  disabled?: boolean;
+}) {
+  const baseClass =
+    "flex items-center justify-center rounded-full border-2 select-none touch-none transition-colors font-[family-name:var(--font-pressstart)] text-xs";
+
+  return (
+    <div className="flex items-end gap-2">
+      <button
+        className={`${baseClass} h-10 w-10 border-[#533483]/60 bg-[#533483]/40 text-gray-400 active:bg-[#533483]/80`}
+        onClick={() => !disabled && onCancel()}
+        aria-label="キャンセル (B)"
+      >
+        B
+      </button>
+      <button
+        className={`${baseClass} h-12 w-12 border-[#e94560]/60 bg-[#e94560]/40 text-white active:bg-[#e94560]/80`}
+        onClick={() => !disabled && onConfirm()}
+        aria-label="決定 (A)"
+      >
+        A
+      </button>
+    </div>
+  );
+}
+
+export function VirtualPad({
+  onDirection,
+  onConfirm,
+  onCancel,
+  onMenu,
+  disabled = false,
+}: VirtualPadProps) {
+  return (
+    <div className="pointer-events-auto absolute inset-x-0 bottom-0 z-30 flex items-end justify-between px-3 pb-3 sm:hidden">
+      {/* 左: 方向パッド */}
+      <DPad onDirection={onDirection} disabled={disabled} />
+
+      {/* 右: A/Bボタン + メニュー */}
+      <div className="flex flex-col items-end gap-2">
+        <button
+          className="flex h-7 items-center rounded-full border border-[#533483]/40 bg-[#16213e]/80 px-3 font-[family-name:var(--font-dotgothic)] text-[10px] text-gray-400 active:bg-[#533483]/60 select-none touch-none"
+          onClick={() => !disabled && onMenu()}
+          aria-label="メニューを開く"
+        >
+          MENU
+        </button>
+        <ActionButtons onConfirm={onConfirm} onCancel={onCancel} disabled={disabled} />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **#140 HUD**: ミニマップ（マップ全体縮小表示+プレイヤー/NPC位置）、先頭モンスターHP表示、操作ガイド（PC用）、NPC会話ヒント「!」マーク
- **#143 歩行アニメ**: プレイヤー2フレーム歩行（方向別・右足/左足）、草タイル揺れエフェクト、水タイルシマーアニメーション
- **#147 バーチャルパッド**: D-pad（長押しリピート対応）、A/B/MENUボタン、smブレイクポイント以下でのみ表示
- **#146 レスポンシブ**: モバイルビューポートスケーリング(85%/72%)、タッチデバイス最適化（選択防止、touch-action）
- **#151 アクセシビリティ**: ARIA role/label追加（タイトル画面、バトル画面、メニュー画面の各要素）
- **#153 カットシーン演出**: バッジ取得アニメーション（SVGバッジ+光芒効果）、殿堂入り画面（パーティ順次表示）、スタッフロール（星空背景+スクロール）

## New Files
- `src/components/ui/OverworldHUD.tsx` - HUDコンポーネント
- `src/components/ui/VirtualPad.tsx` - タッチ用バーチャルパッド
- `src/components/ui/CutsceneOverlay.tsx` - カットシーン演出（バッジ/殿堂入り/スタッフロール）

## Modified Files
- `OverworldScreen.tsx` - HUD/バーチャルパッド/歩行アニメ統合
- `OverworldSprites.tsx` - 歩行フレーム追加（walkFrame prop）
- `Game.tsx` - leadMonster情報をOverworldScreenに渡す
- `globals.css` - grass-sway/water-shimmerアニメ、レスポンシブCSS追加
- `BattleScreen.tsx`, `TitleScreen.tsx`, `MenuScreen.tsx` - ARIA属性追加

## Test plan
- [x] `bun run type-check` パス (0 errors)
- [x] `bun run lint` パス (0 errors, 4 既存warnings)
- [x] `bun run test` パス (513 tests, 35 suites)
- [x] `bun run build` パス

Closes #140, #143, #146, #147, #151, #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)