### PR TITLE
fix: HP0のモンスターが初手で選出されるバグを修正

### DIFF
--- a/src/engine/battle/engine.ts
+++ b/src/engine/battle/engine.ts
@@ -23,6 +23,11 @@ export class BattleEngine {
     moveResolver: MoveResolver,
     random?: () => number,
   ) {
+    const hasAlive = playerParty.some((m) => m.currentHp > 0);
+    if (!hasAlive) {
+      throw new Error("全滅状態でバトルを開始できません");
+    }
+
     this.state = initBattle(playerParty, opponentParty, battleType);
     this.speciesResolver = speciesResolver;
     this.moveResolver = moveResolver;

--- a/src/engine/battle/state-machine.ts
+++ b/src/engine/battle/state-machine.ts
@@ -67,11 +67,22 @@ export function initBattle(
   opponentParty: MonsterInstance[],
   battleType: BattleType,
 ): BattleState {
+  const playerStartIndex = playerParty.findIndex((m) => m.currentHp > 0);
+  const opponentStartIndex = opponentParty.findIndex((m) => m.currentHp > 0);
+
   return {
     phase: "action_select",
     battleType,
-    player: { party: playerParty, activeIndex: 0, statStages: createStatStages() },
-    opponent: { party: opponentParty, activeIndex: 0, statStages: createStatStages() },
+    player: {
+      party: playerParty,
+      activeIndex: playerStartIndex !== -1 ? playerStartIndex : 0,
+      statStages: createStatStages(),
+    },
+    opponent: {
+      party: opponentParty,
+      activeIndex: opponentStartIndex !== -1 ? opponentStartIndex : 0,
+      statStages: createStatStages(),
+    },
     turnNumber: 1,
     escapeAttempts: 0,
     messages: [],


### PR DESCRIPTION
## Summary

- `initBattle()` が `activeIndex: 0` を無条件に設定していたため、先頭モンスターのHPが0でもそのまま選出されていたバグを修正
- `findIndex(m => m.currentHp > 0)` で最初の生存モンスターを探すように変更
- `BattleEngine` コンストラクタに全滅パーティのガード（エラースロー）を追加

## 変更ファイル

- `src/engine/battle/state-machine.ts` — `initBattle()` の `activeIndex` 決定ロジック修正
- `src/engine/battle/engine.ts` — コンストラクタに全滅ガード追加
- `src/engine/battle/__tests__/engine.test.ts` — T7テスト5件追加

## Test plan

- [x] 先頭HP0 → 2番目のモンスターが選出されることを確認
- [x] 先頭2体HP0 → 3番目のモンスターが選出されることを確認
- [x] 相手側もHP0の先頭モンスターをスキップすることを確認
- [x] 全滅パーティでバトル開始時にエラーが投げられることを確認
- [x] HP0スキップ後の正常バトル進行を確認
- [x] 既存テスト全518件パス
- [x] type-check / lint / format パス

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)