### PR TITLE
fix: 全画面のキーボード入力をwindow listenerに統一

### DIFF
--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -1220,6 +1220,7 @@ export function Game() {
       return (
         <>
           <BattleScreen
+            inputBlocked={overlayScreen !== null || pendingMessages !== null}
             player={{
               name: playerActive.nickname ?? playerSpecies.name,
               level: playerActive.level,

--- a/src/components/screens/BagScreen.tsx
+++ b/src/components/screens/BagScreen.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { ItemIcon, type ItemCategory } from "../ui/OverworldSprites";
 
 /**
@@ -39,38 +39,42 @@ export function BagScreen({ items, onUse, onBack }: BagScreenProps) {
   const currentCategory = CATEGORY_ORDER[selectedCategory];
   const filteredItems = items.filter((item) => item.category === currentCategory);
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "ArrowLeft" || e.key === "a") {
-      setSelectedCategory((prev) => (prev - 1 + CATEGORY_ORDER.length) % CATEGORY_ORDER.length);
-      setSelectedItem(0);
-    }
-    if (e.key === "ArrowRight" || e.key === "d") {
-      setSelectedCategory((prev) => (prev + 1) % CATEGORY_ORDER.length);
-      setSelectedItem(0);
-    }
-    if (e.key === "ArrowUp" || e.key === "w") {
-      setSelectedItem((prev) => Math.max(0, prev - 1));
-    }
-    if (e.key === "ArrowDown" || e.key === "s") {
-      setSelectedItem((prev) => Math.min(filteredItems.length - 1, prev + 1));
-    }
-    if (e.key === "Enter" || e.key === "z") {
-      const item = filteredItems[selectedItem];
-      if (item?.usable) {
-        onUse?.(item.itemId);
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "ArrowLeft" || e.key === "a") {
+        setSelectedCategory((prev) => (prev - 1 + CATEGORY_ORDER.length) % CATEGORY_ORDER.length);
+        setSelectedItem(0);
       }
-    }
-    if (e.key === "Escape" || e.key === "x") {
-      onBack();
-    }
-  };
+      if (e.key === "ArrowRight" || e.key === "d") {
+        setSelectedCategory((prev) => (prev + 1) % CATEGORY_ORDER.length);
+        setSelectedItem(0);
+      }
+      if (e.key === "ArrowUp" || e.key === "w") {
+        setSelectedItem((prev) => Math.max(0, prev - 1));
+      }
+      if (e.key === "ArrowDown" || e.key === "s") {
+        setSelectedItem((prev) => Math.min(filteredItems.length - 1, prev + 1));
+      }
+      if (e.key === "Enter" || e.key === "z") {
+        const item = filteredItems[selectedItem];
+        if (item?.usable) {
+          onUse?.(item.itemId);
+        }
+      }
+      if (e.key === "Escape" || e.key === "x") {
+        onBack();
+      }
+    },
+    [filteredItems, selectedItem, onUse, onBack],
+  );
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
 
   return (
-    <div
-      className="flex h-full w-full flex-col bg-[#1a1a2e] p-4"
-      onKeyDown={handleKeyDown}
-      tabIndex={0}
-    >
+    <div className="flex h-full w-full flex-col bg-[#1a1a2e] p-4">
       {/* カテゴリタブ */}
       <div className="mb-3 flex gap-1">
         {CATEGORY_ORDER.map((cat, i) => {

--- a/src/components/screens/MenuScreen.tsx
+++ b/src/components/screens/MenuScreen.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 
 /**
  * メニュー画面 (#77)
@@ -41,38 +41,47 @@ export function MenuScreen({
 }: MenuScreenProps) {
   const [selectedIndex, setSelectedIndex] = useState(0);
 
-  const handleSelect = (index: number) => {
-    const item = MENU_ITEMS[index];
-    if (item.value === "close") {
-      onBack();
-    } else if (item.value === "save") {
-      onSave?.();
-    } else {
-      onNavigate(item.value);
-    }
-  };
+  const handleSelect = useCallback(
+    (index: number) => {
+      const item = MENU_ITEMS[index];
+      if (item.value === "close") {
+        onBack();
+      } else if (item.value === "save") {
+        onSave?.();
+      } else {
+        onNavigate(item.value);
+      }
+    },
+    [onBack, onSave, onNavigate],
+  );
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "ArrowUp" || e.key === "w") {
-      setSelectedIndex((prev) => (prev - 1 + MENU_ITEMS.length) % MENU_ITEMS.length);
-    }
-    if (e.key === "ArrowDown" || e.key === "s") {
-      setSelectedIndex((prev) => (prev + 1) % MENU_ITEMS.length);
-    }
-    if (e.key === "Enter" || e.key === "z") {
-      handleSelect(selectedIndex);
-    }
-    if (e.key === "Escape" || e.key === "x") {
-      onBack();
-    }
-  };
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "ArrowUp" || e.key === "w") {
+        setSelectedIndex((prev) => (prev - 1 + MENU_ITEMS.length) % MENU_ITEMS.length);
+      }
+      if (e.key === "ArrowDown" || e.key === "s") {
+        setSelectedIndex((prev) => (prev + 1) % MENU_ITEMS.length);
+      }
+      if (e.key === "Enter" || e.key === "z") {
+        handleSelect(selectedIndex);
+      }
+      if (e.key === "Escape" || e.key === "x") {
+        onBack();
+      }
+    },
+    [selectedIndex, onBack, handleSelect],
+  );
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
 
   return (
     <div
       className="fixed inset-0 z-40 flex items-start justify-end p-4"
       style={{ backgroundColor: "rgba(10, 10, 26, 0.6)" }}
-      onKeyDown={handleKeyDown}
-      tabIndex={0}
       role="dialog"
       aria-label="メインメニュー"
     >

--- a/src/components/screens/PartyScreen.tsx
+++ b/src/components/screens/PartyScreen.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { HpBar } from "../ui/HpBar";
 import { MonsterSprite } from "../ui/MonsterSprite";
 import { STATUS_COLOR, TYPE_BG, TYPE_LABEL } from "@/lib/design-tokens";
@@ -46,47 +46,54 @@ export function PartyScreen({
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [swapSource, setSwapSource] = useState<number | null>(null);
 
-  const handleSelect = (index: number) => {
-    if (selectMode) {
-      onSelect?.(index);
-      return;
-    }
-
-    if (swapSource !== null) {
-      if (swapSource !== index) {
-        onSwap?.(swapSource, index);
+  const handleSelect = useCallback(
+    (index: number) => {
+      if (selectMode) {
+        onSelect?.(index);
+        return;
       }
-      setSwapSource(null);
-    } else {
-      setSwapSource(index);
-    }
-  };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "ArrowUp" || e.key === "w") {
-      setSelectedIndex((prev) => Math.max(0, prev - 1));
-    }
-    if (e.key === "ArrowDown" || e.key === "s") {
-      setSelectedIndex((prev) => Math.min(party.length - 1, prev + 1));
-    }
-    if (e.key === "Enter" || e.key === "z") {
-      handleSelect(selectedIndex);
-    }
-    if (e.key === "Escape" || e.key === "x") {
       if (swapSource !== null) {
+        if (swapSource !== index) {
+          onSwap?.(swapSource, index);
+        }
         setSwapSource(null);
       } else {
-        onBack();
+        setSwapSource(index);
       }
-    }
-  };
+    },
+    [selectMode, onSelect, swapSource, onSwap],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "ArrowUp" || e.key === "w") {
+        setSelectedIndex((prev) => Math.max(0, prev - 1));
+      }
+      if (e.key === "ArrowDown" || e.key === "s") {
+        setSelectedIndex((prev) => Math.min(party.length - 1, prev + 1));
+      }
+      if (e.key === "Enter" || e.key === "z") {
+        handleSelect(selectedIndex);
+      }
+      if (e.key === "Escape" || e.key === "x") {
+        if (swapSource !== null) {
+          setSwapSource(null);
+        } else {
+          onBack();
+        }
+      }
+    },
+    [selectedIndex, swapSource, party.length, onBack, handleSelect],
+  );
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
 
   return (
-    <div
-      className="flex h-full w-full flex-col bg-[#1a1a2e] p-4"
-      onKeyDown={handleKeyDown}
-      tabIndex={0}
-    >
+    <div className="flex h-full w-full flex-col bg-[#1a1a2e] p-4">
       <h2 className="game-text-shadow mb-3 font-[family-name:var(--font-dotgothic)] text-xl text-white">
         {selectMode ? "モンスターを選んでください" : "てもち"}
       </h2>

--- a/src/components/screens/PokedexScreen.tsx
+++ b/src/components/screens/PokedexScreen.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { MonsterSprite } from "../ui/MonsterSprite";
 import { TYPE_BG, TYPE_LABEL } from "@/lib/design-tokens";
 
@@ -30,24 +30,28 @@ export function PokedexScreen({ entries, onBack }: PokedexScreenProps) {
   const caughtCount = entries.filter((e) => e.caught).length;
   const selected = entries[selectedIndex];
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "ArrowUp" || e.key === "w") {
-      setSelectedIndex((prev) => Math.max(0, prev - 1));
-    }
-    if (e.key === "ArrowDown" || e.key === "s") {
-      setSelectedIndex((prev) => Math.min(entries.length - 1, prev + 1));
-    }
-    if (e.key === "Escape" || e.key === "x") {
-      onBack();
-    }
-  };
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "ArrowUp" || e.key === "w") {
+        setSelectedIndex((prev) => Math.max(0, prev - 1));
+      }
+      if (e.key === "ArrowDown" || e.key === "s") {
+        setSelectedIndex((prev) => Math.min(entries.length - 1, prev + 1));
+      }
+      if (e.key === "Escape" || e.key === "x") {
+        onBack();
+      }
+    },
+    [entries.length, onBack],
+  );
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
 
   return (
-    <div
-      className="flex h-full w-full flex-col bg-[#1a1a2e] p-4"
-      onKeyDown={handleKeyDown}
-      tabIndex={0}
-    >
+    <div className="flex h-full w-full flex-col bg-[#1a1a2e] p-4">
       {/* ヘッダー */}
       <div className="mb-3 flex items-baseline justify-between border-b border-[#533483]/30 pb-3">
         <h2 className="game-text-shadow font-[family-name:var(--font-dotgothic)] text-xl text-white">

--- a/src/components/screens/StarterSelect.tsx
+++ b/src/components/screens/StarterSelect.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { MonsterSprite } from "../ui/MonsterSprite";
 import { TYPE_ACCENT, TYPE_HEX } from "@/lib/design-tokens";
 
@@ -26,36 +26,40 @@ export function StarterSelect({ starters, onSelect, professorName = "博士" }: 
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [confirming, setConfirming] = useState(false);
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (confirming) {
-      if (e.key === "Enter" || e.key === "z") {
-        onSelect(starters[selectedIndex].speciesId);
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (confirming) {
+        if (e.key === "Enter" || e.key === "z") {
+          onSelect(starters[selectedIndex].speciesId);
+        }
+        if (e.key === "Escape" || e.key === "x") {
+          setConfirming(false);
+        }
+        return;
       }
-      if (e.key === "Escape" || e.key === "x") {
-        setConfirming(false);
-      }
-      return;
-    }
 
-    if (e.key === "ArrowLeft" || e.key === "a") {
-      setSelectedIndex((prev) => (prev - 1 + starters.length) % starters.length);
-    }
-    if (e.key === "ArrowRight" || e.key === "d") {
-      setSelectedIndex((prev) => (prev + 1) % starters.length);
-    }
-    if (e.key === "Enter" || e.key === "z") {
-      setConfirming(true);
-    }
-  };
+      if (e.key === "ArrowLeft" || e.key === "a") {
+        setSelectedIndex((prev) => (prev - 1 + starters.length) % starters.length);
+      }
+      if (e.key === "ArrowRight" || e.key === "d") {
+        setSelectedIndex((prev) => (prev + 1) % starters.length);
+      }
+      if (e.key === "Enter" || e.key === "z") {
+        setConfirming(true);
+      }
+    },
+    [confirming, selectedIndex, starters, onSelect],
+  );
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
 
   const selected = starters[selectedIndex];
 
   return (
-    <div
-      className="relative flex h-full w-full flex-col items-center justify-center overflow-hidden bg-[#1a1a2e]"
-      onKeyDown={handleKeyDown}
-      tabIndex={0}
-    >
+    <div className="relative flex h-full w-full flex-col items-center justify-center overflow-hidden bg-[#1a1a2e]">
       {/* 背景エフェクト */}
       <div
         className="pointer-events-none absolute inset-0 transition-all duration-500"

--- a/src/components/screens/TitleScreen.tsx
+++ b/src/components/screens/TitleScreen.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 
 /**
  * タイトル画面 (#54)
@@ -33,23 +33,34 @@ export function TitleScreen({ onNewGame, onContinue, hasSaveData = false }: Titl
     };
   }, []);
 
-  const options = [
-    ...(hasSaveData ? [{ label: "つづきから", action: () => onContinue?.() }] : []),
-    { label: "はじめから", action: () => setShowNameInput(true) },
-  ];
+  const options = useMemo(
+    () => [
+      ...(hasSaveData ? [{ label: "つづきから", action: () => onContinue?.() }] : []),
+      { label: "はじめから", action: () => setShowNameInput(true) },
+    ],
+    [hasSaveData, onContinue],
+  );
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (showNameInput) return;
-    if (e.key === "ArrowUp" || e.key === "w") {
-      setSelectedOption((prev) => (prev - 1 + options.length) % options.length);
-    }
-    if (e.key === "ArrowDown" || e.key === "s") {
-      setSelectedOption((prev) => (prev + 1) % options.length);
-    }
-    if (e.key === "Enter" || e.key === "z" || e.key === " ") {
-      options[selectedOption].action();
-    }
-  };
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (showNameInput) return;
+      if (e.key === "ArrowUp" || e.key === "w") {
+        setSelectedOption((prev) => (prev - 1 + options.length) % options.length);
+      }
+      if (e.key === "ArrowDown" || e.key === "s") {
+        setSelectedOption((prev) => (prev + 1) % options.length);
+      }
+      if (e.key === "Enter" || e.key === "z" || e.key === " ") {
+        options[selectedOption].action();
+      }
+    },
+    [showNameInput, selectedOption, options],
+  );
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
 
   const handleNameSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -62,8 +73,6 @@ export function TitleScreen({ onNewGame, onContinue, hasSaveData = false }: Titl
   return (
     <div
       className="relative flex h-full w-full flex-col items-center justify-center overflow-hidden bg-[#1a1a2e]"
-      onKeyDown={handleKeyDown}
-      tabIndex={0}
       role="main"
       aria-label="Monster Chronicle タイトル画面"
     >

--- a/src/components/ui/MessageWindow.tsx
+++ b/src/components/ui/MessageWindow.tsx
@@ -76,7 +76,7 @@ export function MessageWindow({
   }, [isTyping, isLastPage, showChoices, currentMessage, choices, onComplete]);
 
   const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
+    (e: KeyboardEvent) => {
       if (e.key === " " || e.key === "Enter" || e.key === "z") {
         if (showChoices && choices) {
           onChoice?.(choices[selectedChoice].value);
@@ -96,12 +96,15 @@ export function MessageWindow({
     [showChoices, choices, selectedChoice, onChoice, handleAdvance],
   );
 
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
+
   return (
     <div
       className="fixed bottom-0 left-0 right-0 z-50 mx-auto max-w-2xl p-3"
-      onKeyDown={handleKeyDown}
       onClick={handleAdvance}
-      tabIndex={0}
       role="dialog"
       aria-label="メッセージウィンドウ"
     >


### PR DESCRIPTION
## Summary

- 全画面コンポーネント（8ファイル）のキーボード入力を `window.addEventListener("keydown")` パターンに統一
- DOMフォーカス依存の `onKeyDown` + `tabIndex` パターンを廃止し、クリックでフォーカスが外れてもキー操作が効くように修正
- BattleScreen に `inputBlocked` prop を追加し、オーバーレイ画面表示中のバトル側入力をブロック

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `MenuScreen.tsx` | window listener 化、containerRef/tabIndex/onKeyDown 削除 |
| `BagScreen.tsx` | 同上 |
| `PartyScreen.tsx` | 同上 |
| `PokedexScreen.tsx` | 同上 |
| `TitleScreen.tsx` | 同上 + options を useMemo 化 |
| `StarterSelect.tsx` | 同上 |
| `BattleScreen.tsx` | 同上 + inputBlocked prop 追加 |
| `MessageWindow.tsx` | window listener 化、onClick はそのまま維持 |
| `Game.tsx` | BattleScreen に inputBlocked prop を渡す |

## Test plan

- [x] `bun run type-check` — 型エラーなし
- [x] `bun run lint` — エラー 0（既存 warning のみ）
- [x] `bun run test` — 全1031テスト通過
- [x] `bun run build` — ビルド成功
- [ ] ブラウザでページ内クリック後もキー操作が効くことを確認
- [ ] メニュー → バッグで矢印・Enterが効くことを確認
- [ ] バトル中にキーボードで技選択できることを確認
- [ ] メッセージウィンドウでEnterで送りできることを確認
- [ ] タイトル画面で名前入力中はゲームキーが発動しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)