### PR TITLE
fix: hasSaveDataのハイドレーションミスマッチを修正

### DIFF
--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -112,6 +112,12 @@ export function Game() {
   const state = useGameState();
   const dispatch = useGameDispatch();
 
+  // --- セーブデータ存在チェック（ハイドレーション対策：マウント後に判定） ---
+  const [hasSaveData, setHasSaveData] = useState(false);
+  useEffect(() => {
+    setHasSaveData(localStorage.getItem("pokemon_save_1") !== null);
+  }, []);
+
   // --- バトル状態 ---
   const [battleEngine, setBattleEngine] = useState<BattleEngine | null>(null);
   const [battleMessages, setBattleMessages] = useState<string[]>([]);
@@ -1131,9 +1137,7 @@ export function Game() {
         <TitleScreen
           onNewGame={(name) => dispatch({ type: "START_NEW_GAME", playerName: name })}
           onContinue={handleLoadGame}
-          hasSaveData={
-            typeof window !== "undefined" && localStorage.getItem("pokemon_save_1") !== null
-          }
+          hasSaveData={hasSaveData}
         />
       );
 


### PR DESCRIPTION
## Summary

- TitleScreen の `hasSaveData` 判定で `typeof window !== "undefined" && localStorage.getItem(...)` を使用していたため、SSR時（`false`）とクライアント時（セーブデータがあれば `true`）でレンダリング結果が不一致になりハイドレーションエラーが発生していた
- `useState(false)` + `useEffect` でマウント後に `localStorage` をチェックするパターンに変更し、SSRとクライアントの初回レンダリングを一致させた

## Test plan

- [x] `bun run type-check` — 型エラーなし
- [x] `bun run lint` — エラー 0
- [ ] セーブデータがある状態でページをリロードしてもハイドレーションエラーが出ないこと
- [ ] 「つづきから」オプションがマウント後に正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)