### PR TITLE
fix: MonsterSpriteをmemo化しホバー時のフリーズを修正

### DIFF
--- a/src/components/ui/MonsterSprite.tsx
+++ b/src/components/ui/MonsterSprite.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { memo, useMemo } from "react";
 import { TYPE_HEX } from "@/lib/design-tokens";
 
 /**
@@ -650,7 +651,7 @@ function generateFallbackSprite(
   };
 }
 
-export function MonsterSprite({
+export const MonsterSprite = memo(function MonsterSprite({
   speciesId,
   types,
   size = 64,
@@ -660,7 +661,10 @@ export function MonsterSprite({
 }: MonsterSpriteProps) {
   const primary = getTypeColor(types);
   const secondary = getSecondaryColor(types);
-  const shape = getSpriteShape(speciesId, primary, secondary);
+  const shape = useMemo(
+    () => getSpriteShape(speciesId, primary, secondary),
+    [speciesId, primary, secondary],
+  );
 
   return (
     <div
@@ -700,7 +704,7 @@ export function MonsterSprite({
       </svg>
     </div>
   );
-}
+});
 
 /**
  * オーバーワールド用のミニスプライト


### PR DESCRIPTION
## Summary
- バトルシーン等でモンスターにカーソルをホバーするとフリーズする問題を修正
- `MonsterSprite` を `React.memo` でラップし、propsが変わらない限り再レンダリングをスキップ
- `getSpriteShape()` の結果を `useMemo` でキャッシュし、50体分のスプライト定義オブジェクトの再生成を防止
- バトル中「バッグ」「ポケモン」ボタンを押すとフリーズする問題を修正
- `renderOverlay()` に `absolute inset-0 z-50` を追加し、オーバーレイ画面を正しく全画面表示

## Root Cause

### ホバーフリーズ
`onMouseEnter` でホバーするたびに `setSelectedAction(i)` 等のstate更新が発生し、親コンポーネントが再レンダリング → `MonsterSprite` も再レンダリングされていた。`getSpriteShape()` は毎回50体分の巨大なオブジェクトリテラルを生成するため、連続再レンダリングでCPUが飽和しフリーズしていた。

### バッグ・ポケモンボタンフリーズ
`renderOverlay()` がオーバーレイとして表示されておらず、BagScreen/PartyScreenは `absolute`/`fixed` ポジショニングを持たないため画面外に描画されていた。一方で `overlayScreen !== null` により BattleScreen の `inputBlocked` が `true` になるため、全画面が操作不能＝フリーズ状態になっていた。

## Test plan
- [ ] バトルシーンでモンスタースプライト上をマウスホバーしてフリーズしないことを確認
- [ ] バトル中「バッグ」ボタンを押してバッグ画面が正しく表示されることを確認
- [ ] バトル中「ポケモン」ボタンを押してパーティ画面が正しく表示されることを確認
- [ ] バッグ・パーティ画面から「もどる」でバトル画面に復帰できることを確認
- [ ] オーバーワールドのメニューからもバッグ・パーティ画面が正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)