### PR TITLE
feat: 全50種モンスター図鑑HTMLページを追加

### DIFF
--- a/pokedex.html
+++ b/pokedex.html
@@ -1,0 +1,794 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Monster Chronicle - 図鑑</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700;900&family=Press+Start+2P&display=swap');
+
+  :root {
+    --bg-main: #1a1a2e;
+    --bg-panel: #16213e;
+    --bg-card: #0f3460;
+    --accent: #e94560;
+    --accent-glow: rgba(233, 69, 96, 0.3);
+    --border: rgba(83, 52, 131, 0.5);
+    --text-primary: #ffffff;
+    --text-secondary: #cbd5e1;
+    --text-muted: #64748b;
+
+    --type-normal: #A8A878;
+    --type-fire: #F08030;
+    --type-water: #6890F0;
+    --type-grass: #78C850;
+    --type-electric: #F8D030;
+    --type-ice: #98D8D8;
+    --type-fighting: #C03028;
+    --type-poison: #A040A0;
+    --type-ground: #E0C068;
+    --type-flying: #A890F0;
+    --type-psychic: #F85888;
+    --type-bug: #A8B820;
+    --type-rock: #B8A038;
+    --type-ghost: #705898;
+    --type-dragon: #7038F8;
+    --type-dark: #705848;
+    --type-steel: #B8B8D0;
+    --type-fairy: #EE99AC;
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    background: var(--bg-main);
+    color: var(--text-primary);
+    font-family: 'Noto Sans JP', sans-serif;
+    min-height: 100vh;
+  }
+
+  /* Header */
+  .header {
+    background: linear-gradient(135deg, var(--bg-panel), var(--bg-card));
+    border-bottom: 2px solid var(--border);
+    padding: 2rem;
+    text-align: center;
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    box-shadow: 0 4px 30px rgba(0,0,0,0.5);
+  }
+  .header h1 {
+    font-family: 'Press Start 2P', monospace;
+    font-size: 1.5rem;
+    color: var(--accent);
+    text-shadow: 0 0 20px var(--accent-glow);
+    margin-bottom: 0.5rem;
+  }
+  .header p {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+  }
+
+  /* Filter */
+  .filter-bar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    justify-content: center;
+    margin-top: 1rem;
+  }
+  .filter-btn {
+    font-family: 'Noto Sans JP', sans-serif;
+    font-size: 0.7rem;
+    font-weight: 700;
+    padding: 0.3rem 0.7rem;
+    border-radius: 999px;
+    border: 1.5px solid rgba(255,255,255,0.15);
+    background: rgba(255,255,255,0.05);
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: all 0.2s;
+  }
+  .filter-btn:hover, .filter-btn.active {
+    background: rgba(255,255,255,0.15);
+    border-color: rgba(255,255,255,0.4);
+    color: #fff;
+  }
+  .filter-btn.active {
+    box-shadow: 0 0 8px rgba(255,255,255,0.1);
+  }
+
+  /* Grid */
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 1rem;
+    padding: 1.5rem;
+    max-width: 1400px;
+    margin: 0 auto;
+  }
+
+  /* Card */
+  .card {
+    background: linear-gradient(135deg, var(--bg-panel), var(--bg-card));
+    border: 2px solid var(--border);
+    border-radius: 12px;
+    overflow: hidden;
+    transition: transform 0.2s, box-shadow 0.2s;
+    cursor: pointer;
+    position: relative;
+  }
+  .card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 8px 30px rgba(0,0,0,0.4), 0 0 20px var(--accent-glow);
+    border-color: rgba(233, 69, 96, 0.4);
+  }
+  .card.legendary {
+    border-color: rgba(248, 208, 48, 0.5);
+  }
+  .card.legendary:hover {
+    box-shadow: 0 8px 30px rgba(0,0,0,0.4), 0 0 20px rgba(248, 208, 48, 0.3);
+  }
+
+  .card-top {
+    display: flex;
+    align-items: center;
+    padding: 1rem;
+    gap: 1rem;
+  }
+  .sprite-container {
+    flex-shrink: 0;
+    width: 80px;
+    height: 80px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(255,255,255,0.03);
+    border-radius: 12px;
+  }
+  .card-info {
+    flex: 1;
+    min-width: 0;
+  }
+  .card-number {
+    font-family: 'Press Start 2P', monospace;
+    font-size: 0.55rem;
+    color: var(--text-muted);
+  }
+  .card-name {
+    font-size: 1.1rem;
+    font-weight: 900;
+    margin: 0.2rem 0;
+  }
+  .card-id {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    font-style: italic;
+  }
+  .types {
+    display: flex;
+    gap: 0.3rem;
+    margin-top: 0.4rem;
+  }
+  .type-badge {
+    font-size: 0.65rem;
+    font-weight: 700;
+    padding: 0.15rem 0.6rem;
+    border-radius: 999px;
+    color: #fff;
+    text-shadow: 0 1px 2px rgba(0,0,0,0.3);
+  }
+
+  /* Stats */
+  .stats {
+    padding: 0 1rem 0.8rem;
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    gap: 0.3rem;
+  }
+  .stat {
+    text-align: center;
+  }
+  .stat-label {
+    font-size: 0.5rem;
+    font-weight: 700;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+  .stat-value {
+    font-size: 0.8rem;
+    font-weight: 900;
+  }
+  .stat-bar {
+    height: 3px;
+    background: rgba(255,255,255,0.1);
+    border-radius: 2px;
+    margin-top: 2px;
+    overflow: hidden;
+  }
+  .stat-fill {
+    height: 100%;
+    border-radius: 2px;
+    transition: width 0.5s ease;
+  }
+  .stat-total {
+    text-align: center;
+    font-size: 0.65rem;
+    color: var(--text-muted);
+    padding: 0 1rem 0.6rem;
+  }
+  .stat-total span {
+    font-weight: 900;
+    color: var(--text-secondary);
+  }
+
+  /* Evolution */
+  .evolution {
+    padding: 0 1rem 0.8rem;
+    font-size: 0.7rem;
+    color: var(--text-muted);
+  }
+  .evolution .evo-arrow {
+    color: var(--accent);
+    font-weight: 700;
+  }
+  .evolution .evo-name {
+    color: var(--text-secondary);
+    font-weight: 700;
+  }
+
+  /* Legend badge */
+  .legend-badge {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    font-family: 'Press Start 2P', monospace;
+    font-size: 0.45rem;
+    padding: 0.2rem 0.5rem;
+    background: linear-gradient(135deg, #F8D030, #E0C068);
+    color: #1a1a2e;
+    border-radius: 4px;
+  }
+
+  /* Empty state */
+  .empty {
+    grid-column: 1 / -1;
+    text-align: center;
+    padding: 4rem 2rem;
+    color: var(--text-muted);
+    font-size: 1.1rem;
+  }
+
+  /* Animations */
+  .card { animation: fadeIn 0.3s ease forwards; opacity: 0; }
+  @keyframes fadeIn { to { opacity: 1; } }
+
+  /* Stat color helper */
+  .stat-high { color: #34D399; }
+  .stat-mid { color: #FBBF24; }
+  .stat-low { color: #EF4444; }
+</style>
+</head>
+<body>
+
+<div class="header">
+  <h1>MONSTER CHRONICLE</h1>
+  <p>全50種 モンスター図鑑</p>
+  <div class="filter-bar" id="filterBar"></div>
+</div>
+
+<div class="grid" id="monsterGrid"></div>
+
+<script>
+// ─── Type Data ───
+const TYPE_HEX = {
+  normal:"#A8A878", fire:"#F08030", water:"#6890F0", grass:"#78C850",
+  electric:"#F8D030", ice:"#98D8D8", fighting:"#C03028", poison:"#A040A0",
+  ground:"#E0C068", flying:"#A890F0", psychic:"#F85888", bug:"#A8B820",
+  rock:"#B8A038", ghost:"#705898", dragon:"#7038F8", dark:"#705848",
+  steel:"#B8B8D0", fairy:"#EE99AC"
+};
+
+const TYPE_LABEL = {
+  normal:"ノーマル", fire:"ほのお", water:"みず", grass:"くさ",
+  electric:"でんき", ice:"こおり", fighting:"かくとう", poison:"どく",
+  ground:"じめん", flying:"ひこう", psychic:"エスパー", bug:"むし",
+  rock:"いわ", ghost:"ゴースト", dragon:"ドラゴン", dark:"あく",
+  steel:"はがね", fairy:"フェアリー"
+};
+
+// ─── Color Helpers ───
+function lightenColor(hex, amount) {
+  const r = Math.min(255, parseInt(hex.slice(1,3),16) + amount);
+  const g = Math.min(255, parseInt(hex.slice(3,5),16) + amount);
+  const b = Math.min(255, parseInt(hex.slice(5,7),16) + amount);
+  return `#${r.toString(16).padStart(2,'0')}${g.toString(16).padStart(2,'0')}${b.toString(16).padStart(2,'0')}`;
+}
+function darkenColor(hex, amount) {
+  const r = Math.max(0, parseInt(hex.slice(1,3),16) - amount);
+  const g = Math.max(0, parseInt(hex.slice(3,5),16) - amount);
+  const b = Math.max(0, parseInt(hex.slice(5,7),16) - amount);
+  return `#${r.toString(16).padStart(2,'0')}${g.toString(16).padStart(2,'0')}${b.toString(16).padStart(2,'0')}`;
+}
+
+function getTypeColor(types) { return TYPE_HEX[types[0]] || "#A8A878"; }
+function getSecondaryColor(types) {
+  if (types.length > 1) return TYPE_HEX[types[1]] || "#A8A878";
+  return lightenColor(TYPE_HEX[types[0]] || "#A8A878", 40);
+}
+
+// ─── Sprite Shapes ───
+function getSpriteShape(id, primary, secondary) {
+  const dark = darkenColor(primary, 40);
+  const light = lightenColor(primary, 30);
+  const eyeColor = "#FFFFFF";
+
+  const sprites = {
+    himori: {
+      body: `<ellipse cx="32" cy="38" rx="14" ry="12" fill="${primary}"/><ellipse cx="32" cy="28" rx="10" ry="9" fill="${primary}"/><path d="M22 40 Q18 48 22 50 Q26 52 28 46" fill="${dark}"/><path d="M36 40 Q40 48 42 50 Q46 52 42 46" fill="${dark}"/>`,
+      eyes: `<circle cx="28" cy="26" r="2.5" fill="${eyeColor}"/><circle cx="28" cy="26" r="1.5" fill="#333"/><circle cx="36" cy="26" r="2.5" fill="${eyeColor}"/><circle cx="36" cy="26" r="1.5" fill="#333"/>`,
+      details: `<path d="M32 18 Q34 12 30 10 Q36 14 38 12 Q35 18 32 18" fill="#FF6030" opacity="0.9"/>`,
+      accent: `<circle cx="32" cy="34" r="3" fill="#FFCC00" opacity="0.5"/>`
+    },
+    hinomori: {
+      body: `<ellipse cx="32" cy="36" rx="16" ry="14" fill="${primary}"/><ellipse cx="32" cy="24" rx="12" ry="10" fill="${primary}"/><path d="M20 38 Q14 48 18 52 Q22 54 24 46" fill="${dark}"/><path d="M38 38 Q44 48 46 52 Q50 54 44 46" fill="${dark}"/>`,
+      eyes: `<circle cx="26" cy="22" r="3" fill="${eyeColor}"/><circle cx="27" cy="22" r="1.8" fill="#333"/><circle cx="38" cy="22" r="3" fill="${eyeColor}"/><circle cx="37" cy="22" r="1.8" fill="#333"/>`,
+      details: `<path d="M32 14 Q36 6 30 4 Q38 8 42 6 Q37 14 32 14" fill="#FF6030"/><path d="M28 14 Q24 6 26 4" fill="#FF8040" opacity="0.7"/>`,
+      accent: `<path d="M26 32 Q32 28 38 32 Q32 36 26 32" fill="#FFCC00" opacity="0.4"/>`
+    },
+    enjuu: {
+      body: `<ellipse cx="32" cy="34" rx="18" ry="16" fill="${primary}"/><ellipse cx="32" cy="20" rx="13" ry="11" fill="${primary}"/><path d="M18 36 Q10 46 14 52 Q20 56 22 44" fill="${dark}"/><path d="M42 36 Q50 46 50 52 Q46 56 42 44" fill="${dark}"/><path d="M26 50 Q24 56 28 58" fill="${dark}"/><path d="M38 50 Q40 56 36 58" fill="${dark}"/>`,
+      eyes: `<path d="M24 18 L22 16 L28 16 Z" fill="${eyeColor}"/><circle cx="25" cy="18" r="1.5" fill="#C03028"/><path d="M36 18 L42 16 L40 16 Z" fill="${eyeColor}"/><circle cx="39" cy="18" r="1.5" fill="#C03028"/>`,
+      details: `<path d="M32 10 Q38 0 28 -2 Q40 4 46 0 Q40 10 32 10" fill="#FF4020"/><path d="M22 10 Q18 2 20 -2 Q14 4 22 10" fill="#FF6030" opacity="0.8"/>`,
+      accent: `<path d="M24 30 Q32 24 40 30 Q32 36 24 30" fill="${secondary}" opacity="0.3"/><circle cx="20" cy="26" r="1" fill="#FFF" opacity="0.6"/><circle cx="44" cy="26" r="1" fill="#FFF" opacity="0.6"/>`
+    },
+    shizukumo: {
+      body: `<ellipse cx="32" cy="36" rx="12" ry="10" fill="${primary}"/><circle cx="32" cy="26" r="10" fill="${primary}"/>`,
+      eyes: `<circle cx="28" cy="24" r="3" fill="${eyeColor}"/><circle cx="28" cy="25" r="1.8" fill="#333"/><circle cx="36" cy="24" r="3" fill="${eyeColor}"/><circle cx="36" cy="25" r="1.8" fill="#333"/>`,
+      details: `<path d="M22 30 Q16 34 18 38 Q14 30 22 30" fill="${dark}" opacity="0.6"/><path d="M42 30 Q48 34 46 38 Q50 30 42 30" fill="${dark}" opacity="0.6"/><path d="M26 30 Q22 36 26 40" fill="${dark}" opacity="0.4"/><path d="M38 30 Q42 36 38 40" fill="${dark}" opacity="0.4"/>`,
+      accent: `<circle cx="32" cy="18" r="2" fill="${light}" opacity="0.5"/>`
+    },
+    namikozou: {
+      body: `<ellipse cx="32" cy="36" rx="15" ry="12" fill="${primary}"/><circle cx="32" cy="24" r="12" fill="${primary}"/><path d="M20 40 Q16 48 20 50" fill="${dark}"/><path d="M44 40 Q48 48 44 50" fill="${dark}"/>`,
+      eyes: `<circle cx="26" cy="22" r="3.5" fill="${eyeColor}"/><circle cx="27" cy="22" r="2" fill="#333"/><circle cx="38" cy="22" r="3.5" fill="${eyeColor}"/><circle cx="37" cy="22" r="2" fill="#333"/>`,
+      details: `<path d="M20 28 Q12 32 14 40 Q10 28 20 28" fill="${dark}" opacity="0.5"/><path d="M44 28 Q52 32 50 40 Q54 28 44 28" fill="${dark}" opacity="0.5"/>`,
+      accent: `<path d="M26 16 Q32 12 38 16" fill="${light}" opacity="0.6" stroke="${light}" stroke-width="1"/>`
+    },
+    taikaiou: {
+      body: `<ellipse cx="32" cy="34" rx="18" ry="15" fill="${primary}"/><ellipse cx="32" cy="20" rx="14" ry="12" fill="${primary}"/><path d="M16 36 Q8 44 12 50 Q18 54 20 42" fill="${dark}"/><path d="M48 36 Q54 44 52 50 Q46 54 44 42" fill="${dark}"/>`,
+      eyes: `<ellipse cx="24" cy="18" rx="3" ry="3.5" fill="${eyeColor}"/><circle cx="25" cy="18" r="2" fill="#F85888"/><ellipse cx="40" cy="18" rx="3" ry="3.5" fill="${eyeColor}"/><circle cx="39" cy="18" r="2" fill="#F85888"/>`,
+      details: `<path d="M32 8 Q28 4 24 8 Q28 6 32 8" fill="${light}"/><path d="M32 8 Q36 4 40 8 Q36 6 32 8" fill="${light}"/>`,
+      accent: `<circle cx="32" cy="28" r="4" fill="${secondary}" opacity="0.3"/><circle cx="32" cy="28" r="2" fill="#FFF" opacity="0.2"/>`
+    },
+    konohana: {
+      body: `<ellipse cx="32" cy="38" rx="12" ry="10" fill="${primary}"/><circle cx="32" cy="28" r="9" fill="${primary}"/>`,
+      eyes: `<circle cx="28" cy="26" r="2.5" fill="${eyeColor}"/><circle cx="28" cy="27" r="1.5" fill="#333"/><circle cx="36" cy="26" r="2.5" fill="${eyeColor}"/><circle cx="36" cy="27" r="1.5" fill="#333"/>`,
+      details: `<path d="M24 22 Q20 16 16 18 Q20 20 24 22" fill="#4CAF50"/><path d="M40 22 Q44 16 48 18 Q44 20 40 22" fill="#4CAF50"/>`,
+      accent: `<circle cx="32" cy="20" r="3" fill="#A5D6A7" opacity="0.5"/><path d="M30 19 L32 15 L34 19" fill="#66BB6A" opacity="0.7"/>`
+    },
+    morinoko: {
+      body: `<ellipse cx="32" cy="36" rx="14" ry="12" fill="${primary}"/><ellipse cx="32" cy="24" rx="11" ry="10" fill="${primary}"/><path d="M22 40 Q18 48 22 52" fill="${dark}"/><path d="M42 40 Q46 48 42 52" fill="${dark}"/>`,
+      eyes: `<circle cx="26" cy="22" r="3" fill="${eyeColor}"/><circle cx="27" cy="22" r="1.8" fill="#333"/><circle cx="38" cy="22" r="3" fill="${eyeColor}"/><circle cx="37" cy="22" r="1.8" fill="#333"/>`,
+      details: `<path d="M22 18 Q16 12 12 16 Q18 16 22 18" fill="#388E3C"/><path d="M42 18 Q48 12 52 16 Q46 16 42 18" fill="#388E3C"/><path d="M32 14 Q30 8 32 6 Q34 8 32 14" fill="#66BB6A"/>`,
+      accent: `<circle cx="28" cy="32" r="2" fill="#A5D6A7" opacity="0.4"/><circle cx="36" cy="32" r="2" fill="#A5D6A7" opacity="0.4"/>`
+    },
+    taijushin: {
+      body: `<ellipse cx="32" cy="34" rx="18" ry="16" fill="${primary}"/><ellipse cx="32" cy="20" rx="13" ry="11" fill="${primary}"/><rect x="18" y="44" width="8" height="10" rx="3" fill="${dark}"/><rect x="38" y="44" width="8" height="10" rx="3" fill="${dark}"/>`,
+      eyes: `<path d="M22 18 L27 16 L27 20 Z" fill="${eyeColor}"/><circle cx="25" cy="18" r="1.5" fill="#333"/><path d="M42 18 L37 16 L37 20 Z" fill="${eyeColor}"/><circle cx="39" cy="18" r="1.5" fill="#333"/>`,
+      details: `<path d="M18 16 Q10 8 8 14 Q14 12 18 16" fill="#388E3C"/><path d="M46 16 Q54 8 56 14 Q50 12 46 16" fill="#388E3C"/><path d="M32 10 Q28 2 32 0 Q36 2 32 10" fill="#66BB6A"/>`,
+      accent: `<path d="M24 30 Q32 26 40 30" fill="${secondary}" opacity="0.3" stroke="${secondary}" stroke-width="1"/><circle cx="32" cy="28" r="3" fill="${secondary}" opacity="0.2"/>`
+    },
+    konezumi: {
+      body: `<ellipse cx="32" cy="38" rx="10" ry="8" fill="${primary}"/><circle cx="32" cy="30" r="8" fill="${primary}"/><path d="M26 34 Q22 40 26 42" fill="${dark}"/><path d="M38 34 Q42 40 38 42" fill="${dark}"/>`,
+      eyes: `<circle cx="29" cy="28" r="2" fill="${eyeColor}"/><circle cx="29" cy="28" r="1.2" fill="#333"/><circle cx="35" cy="28" r="2" fill="${eyeColor}"/><circle cx="35" cy="28" r="1.2" fill="#333"/>`,
+      details: `<path d="M28 24 Q26 20 24 22" fill="${light}"/><path d="M36 24 Q38 20 40 22" fill="${light}"/><path d="M40 36 Q48 38 50 34" fill="${primary}" opacity="0.7"/>`,
+      accent: `<circle cx="32" cy="32" r="1" fill="#FFB6C1" opacity="0.6"/>`
+    },
+    oonezumi: {
+      body: `<ellipse cx="32" cy="36" rx="14" ry="10" fill="${primary}"/><ellipse cx="32" cy="26" rx="10" ry="9" fill="${primary}"/><path d="M22 38 Q16 46 20 48" fill="${dark}"/><path d="M42 38 Q48 46 44 48" fill="${dark}"/>`,
+      eyes: `<path d="M26 24 L24 22 L30 23 Z" fill="${eyeColor}"/><circle cx="27" cy="24" r="1.5" fill="#C03028"/><path d="M38 24 L40 22 L34 23 Z" fill="${eyeColor}"/><circle cx="37" cy="24" r="1.5" fill="#C03028"/>`,
+      details: `<path d="M26 20 Q22 14 20 18" fill="${light}"/><path d="M38 20 Q42 14 44 18" fill="${light}"/><path d="M42 34 Q52 36 56 30" fill="${primary}" opacity="0.6"/>`,
+      accent: ``
+    },
+    tobibato: {
+      body: `<ellipse cx="32" cy="34" rx="12" ry="10" fill="${primary}"/><circle cx="32" cy="26" r="8" fill="${primary}"/><path d="M20 30 Q10 24 14 20" fill="${light}" opacity="0.8"/><path d="M44 30 Q54 24 50 20" fill="${light}" opacity="0.8"/>`,
+      eyes: `<circle cx="28" cy="24" r="2" fill="${eyeColor}"/><circle cx="29" cy="24" r="1.2" fill="#333"/><circle cx="36" cy="24" r="2" fill="${eyeColor}"/><circle cx="35" cy="24" r="1.2" fill="#333"/>`,
+      details: `<path d="M30 28 L32 32 L34 28" fill="#F8D030" opacity="0.7"/>`,
+      accent: ``
+    },
+    hayatedori: {
+      body: `<ellipse cx="32" cy="32" rx="14" ry="12" fill="${primary}"/><ellipse cx="32" cy="22" rx="10" ry="9" fill="${primary}"/><path d="M18 28 Q4 18 10 14" fill="${light}"/><path d="M46 28 Q60 18 54 14" fill="${light}"/>`,
+      eyes: `<path d="M26 20 L24 18 L30 19 Z" fill="${eyeColor}"/><circle cx="27" cy="20" r="1.5" fill="#333"/><path d="M38 20 L40 18 L34 19 Z" fill="${eyeColor}"/><circle cx="37" cy="20" r="1.5" fill="#333"/>`,
+      details: `<path d="M28 24 L32 30 L36 24" fill="${dark}" opacity="0.4"/><path d="M32 14 Q30 10 32 8 Q34 10 32 14" fill="${secondary}" opacity="0.7"/>`,
+      accent: ``
+    },
+    mayumushi: {
+      body: `<ellipse cx="32" cy="38" rx="10" ry="8" fill="${primary}"/><circle cx="32" cy="30" r="8" fill="${primary}"/>`,
+      eyes: `<circle cx="28" cy="28" r="3" fill="${eyeColor}"/><circle cx="28" cy="29" r="1.8" fill="#333"/><circle cx="36" cy="28" r="3" fill="${eyeColor}"/><circle cx="36" cy="29" r="1.8" fill="#333"/>`,
+      details: `<path d="M22 34 Q18 38 16 36" fill="${dark}" opacity="0.5"/><path d="M42 34 Q46 38 48 36" fill="${dark}" opacity="0.5"/><path d="M24 34 Q20 40 18 38" fill="${dark}" opacity="0.3"/><path d="M40 34 Q44 40 46 38" fill="${dark}" opacity="0.3"/>`,
+      accent: ``
+    },
+    hanamushi: {
+      body: `<ellipse cx="32" cy="34" rx="12" ry="10" fill="${primary}"/><circle cx="32" cy="24" r="9" fill="${primary}"/><path d="M18 28 Q8 20 14 16" fill="${light}" opacity="0.7"/><path d="M46 28 Q56 20 50 16" fill="${light}" opacity="0.7"/>`,
+      eyes: `<circle cx="27" cy="22" r="2.5" fill="${eyeColor}"/><circle cx="27" cy="23" r="1.5" fill="#7038F8"/><circle cx="37" cy="22" r="2.5" fill="${eyeColor}"/><circle cx="37" cy="23" r="1.5" fill="#7038F8"/>`,
+      details: `<circle cx="26" cy="16" r="3" fill="#FF69B4" opacity="0.6"/><circle cx="38" cy="16" r="3" fill="#FF69B4" opacity="0.6"/><circle cx="32" cy="14" r="2.5" fill="#FF69B4" opacity="0.7"/>`,
+      accent: ``
+    },
+    hikarineko: {
+      body: `<ellipse cx="32" cy="36" rx="12" ry="10" fill="${primary}"/><circle cx="32" cy="26" r="10" fill="${primary}"/><path d="M24 38 Q20 46 24 48" fill="${dark}"/><path d="M40 38 Q44 46 40 48" fill="${dark}"/>`,
+      eyes: `<circle cx="28" cy="24" r="3" fill="${eyeColor}"/><circle cx="28" cy="24" r="2" fill="#F8D030"/><circle cx="36" cy="24" r="3" fill="${eyeColor}"/><circle cx="36" cy="24" r="2" fill="#F8D030"/>`,
+      details: `<path d="M24 18 Q20 10 18 14" fill="${primary}"/><path d="M40 18 Q44 10 46 14" fill="${primary}"/><path d="M40 36 Q48 38 52 36 Q50 40 46 38" fill="${primary}"/>`,
+      accent: `<path d="M26 16 Q32 14 38 16" fill="#FFF176" opacity="0.5"/><circle cx="32" cy="20" r="1.5" fill="#FFEB3B" opacity="0.7"/>`
+    },
+    dokudama: {
+      body: `<circle cx="32" cy="32" r="12" fill="${primary}"/>`,
+      eyes: `<circle cx="27" cy="30" r="2.5" fill="${eyeColor}"/><circle cx="27" cy="30" r="1.5" fill="#333"/><circle cx="37" cy="30" r="2.5" fill="${eyeColor}"/><circle cx="37" cy="30" r="1.5" fill="#333"/>`,
+      details: `<circle cx="26" cy="24" r="2" fill="${dark}" opacity="0.4"/><circle cx="38" cy="26" r="1.5" fill="${dark}" opacity="0.3"/><circle cx="30" cy="38" r="1.5" fill="${dark}" opacity="0.3"/>`,
+      accent: `<path d="M32 22 Q30 18 32 16 Q34 18 32 22" fill="${light}" opacity="0.5"/>`
+    },
+    dokunuma: {
+      body: `<ellipse cx="32" cy="36" rx="16" ry="12" fill="${primary}"/><ellipse cx="32" cy="26" rx="12" ry="10" fill="${primary}"/>`,
+      eyes: `<path d="M24 24 L22 22 L28 23 Z" fill="${eyeColor}"/><circle cx="25" cy="24" r="1.5" fill="#C03028"/><path d="M40 24 L42 22 L36 23 Z" fill="${eyeColor}"/><circle cx="39" cy="24" r="1.5" fill="#C03028"/>`,
+      details: `<ellipse cx="32" cy="44" rx="14" ry="4" fill="${secondary}" opacity="0.4"/><circle cx="24" cy="20" r="2" fill="${dark}" opacity="0.3"/><circle cx="40" cy="22" r="1.5" fill="${dark}" opacity="0.3"/>`,
+      accent: ``
+    },
+    kawadojou: {
+      body: `<ellipse cx="32" cy="34" rx="18" ry="8" fill="${primary}"/><ellipse cx="24" cy="30" rx="8" ry="7" fill="${primary}"/>`,
+      eyes: `<circle cx="20" cy="28" r="2" fill="${eyeColor}"/><circle cx="20" cy="28" r="1.2" fill="#333"/><circle cx="28" cy="28" r="2" fill="${eyeColor}"/><circle cx="28" cy="28" r="1.2" fill="#333"/>`,
+      details: `<path d="M40 30 Q50 28 54 32 Q50 36 44 34" fill="${dark}" opacity="0.4"/><path d="M18 32 Q16 34 20 36" fill="${secondary}" opacity="0.4"/>`,
+      accent: ``
+    },
+    hidane: {
+      body: `<ellipse cx="32" cy="36" rx="10" ry="9" fill="${primary}"/><circle cx="32" cy="28" r="8" fill="${primary}"/>`,
+      eyes: `<circle cx="28" cy="26" r="2" fill="${eyeColor}"/><circle cx="28" cy="27" r="1.2" fill="#333"/><circle cx="36" cy="26" r="2" fill="${eyeColor}"/><circle cx="36" cy="27" r="1.2" fill="#333"/>`,
+      details: `<path d="M32 20 Q30 14 32 12 Q34 14 32 20" fill="#FF6030" opacity="0.8"/>`,
+      accent: `<circle cx="32" cy="32" r="2.5" fill="#FFCC00" opacity="0.4"/>`
+    },
+    kaenjishi: {
+      body: `<ellipse cx="32" cy="34" rx="16" ry="14" fill="${primary}"/><ellipse cx="32" cy="22" rx="12" ry="10" fill="${primary}"/><path d="M20 36 Q12 46 16 50" fill="${dark}"/><path d="M44 36 Q52 46 48 50" fill="${dark}"/>`,
+      eyes: `<path d="M24 20 L22 18 L28 19 Z" fill="${eyeColor}"/><circle cx="25" cy="20" r="1.5" fill="#FF6030"/><path d="M40 20 L42 18 L36 19 Z" fill="${eyeColor}"/><circle cx="39" cy="20" r="1.5" fill="#FF6030"/>`,
+      details: `<path d="M20 16 Q14 8 18 6 Q22 10 20 16" fill="#FF8040"/><path d="M44 16 Q50 8 46 6 Q42 10 44 16" fill="#FF8040"/><path d="M32 12 Q28 4 32 2 Q36 4 32 12" fill="#FF6030"/>`,
+      accent: ``
+    },
+    tsuchikobushi: {
+      body: `<ellipse cx="32" cy="36" rx="14" ry="12" fill="${primary}"/><ellipse cx="32" cy="26" rx="10" ry="9" fill="${primary}"/>`,
+      eyes: `<rect x="26" y="24" width="4" height="3" rx="1" fill="${eyeColor}"/><circle cx="28" cy="25" r="1" fill="#333"/><rect x="34" y="24" width="4" height="3" rx="1" fill="${eyeColor}"/><circle cx="36" cy="25" r="1" fill="#333"/>`,
+      details: `<path d="M18 32 Q14 28 18 26" fill="${dark}" opacity="0.5"/><path d="M46 32 Q50 28 46 26" fill="${dark}" opacity="0.5"/>`,
+      accent: ``
+    },
+    iwakenjin: {
+      body: `<ellipse cx="32" cy="34" rx="18" ry="16" fill="${primary}"/><ellipse cx="32" cy="20" rx="12" ry="10" fill="${primary}"/><rect x="14" y="40" width="10" height="12" rx="3" fill="${dark}"/><rect x="40" y="40" width="10" height="12" rx="3" fill="${dark}"/>`,
+      eyes: `<path d="M24 18 L22 16 L28 17 Z" fill="${eyeColor}"/><circle cx="25" cy="18" r="1.5" fill="#C03028"/><path d="M40 18 L42 16 L36 17 Z" fill="${eyeColor}"/><circle cx="39" cy="18" r="1.5" fill="#C03028"/>`,
+      details: `<path d="M20 24 Q14 20 16 16" fill="${secondary}" opacity="0.5"/><path d="M44 24 Q50 20 48 16" fill="${secondary}" opacity="0.5"/>`,
+      accent: ``
+    },
+    mogurakko: {
+      body: `<ellipse cx="32" cy="38" rx="12" ry="8" fill="${primary}"/><circle cx="32" cy="30" r="10" fill="${primary}"/>`,
+      eyes: `<path d="M26 28 L30 28" stroke="#333" stroke-width="2" stroke-linecap="round"/><path d="M34 28 L38 28" stroke="#333" stroke-width="2" stroke-linecap="round"/>`,
+      details: `<circle cx="32" cy="32" r="3" fill="#FFB6C1" opacity="0.6"/><path d="M20 34 Q16 30 14 32" fill="${dark}" opacity="0.5"/><path d="M44 34 Q48 30 50 32" fill="${dark}" opacity="0.5"/>`,
+      accent: ``
+    },
+    dogou: {
+      body: `<ellipse cx="32" cy="34" rx="16" ry="14" fill="${primary}"/><ellipse cx="32" cy="22" rx="12" ry="10" fill="${primary}"/><rect x="16" y="42" width="10" height="10" rx="3" fill="${dark}"/><rect x="38" y="42" width="10" height="10" rx="3" fill="${dark}"/>`,
+      eyes: `<rect x="24" y="20" width="5" height="3" rx="1" fill="${eyeColor}"/><circle cx="26" cy="21" r="1" fill="#B8B8D0"/><rect x="35" y="20" width="5" height="3" rx="1" fill="${eyeColor}"/><circle cx="38" cy="21" r="1" fill="#B8B8D0"/>`,
+      details: `<path d="M22 16 Q18 10 22 8" fill="${secondary}" opacity="0.5"/><path d="M42 16 Q46 10 42 8" fill="${secondary}" opacity="0.5"/><circle cx="32" cy="28" r="3" fill="${secondary}" opacity="0.3"/>`,
+      accent: ``
+    },
+    yurabi: {
+      body: `<path d="M32 20 Q20 26 22 42 Q26 48 32 44 Q38 48 42 42 Q44 26 32 20" fill="${primary}" opacity="0.8"/>`,
+      eyes: `<circle cx="28" cy="30" r="2.5" fill="#FF4444" opacity="0.8"/><circle cx="28" cy="30" r="1" fill="#FFCCCC"/><circle cx="36" cy="30" r="2.5" fill="#FF4444" opacity="0.8"/><circle cx="36" cy="30" r="1" fill="#FFCCCC"/>`,
+      details: `<path d="M26 38 Q24 44 26 48" fill="${primary}" opacity="0.5"/><path d="M38 38 Q40 44 38 48" fill="${primary}" opacity="0.5"/>`,
+      accent: ``
+    },
+    kageboushi: {
+      body: `<path d="M32 16 Q18 22 20 40 Q24 48 32 44 Q40 48 44 40 Q46 22 32 16" fill="${primary}" opacity="0.85"/>`,
+      eyes: `<ellipse cx="26" cy="28" rx="3" ry="2.5" fill="#F85888" opacity="0.9"/><circle cx="26" cy="28" r="1.2" fill="#FFF"/><ellipse cx="38" cy="28" rx="3" ry="2.5" fill="#F85888" opacity="0.9"/><circle cx="38" cy="28" r="1.2" fill="#FFF"/>`,
+      details: `<path d="M24 36 Q20 44 24 50" fill="${primary}" opacity="0.4"/><path d="M40 36 Q44 44 40 50" fill="${primary}" opacity="0.4"/><path d="M32 18 Q28 12 32 10 Q36 12 32 18" fill="${secondary}" opacity="0.5"/>`,
+      accent: ``
+    },
+    yomikagura: {
+      body: `<path d="M32 12 Q14 20 16 38 Q20 50 32 46 Q44 50 48 38 Q50 20 32 12" fill="${primary}" opacity="0.9"/>`,
+      eyes: `<ellipse cx="24" cy="26" rx="4" ry="3" fill="#F85888"/><circle cx="24" cy="26" r="1.5" fill="#FFF"/><ellipse cx="40" cy="26" rx="4" ry="3" fill="#F85888"/><circle cx="40" cy="26" r="1.5" fill="#FFF"/>`,
+      details: `<path d="M22 36 Q16 46 22 54" fill="${primary}" opacity="0.4"/><path d="M42 36 Q48 46 42 54" fill="${primary}" opacity="0.4"/><path d="M28 36 Q24 44 28 50" fill="${primary}" opacity="0.3"/><path d="M36 36 Q40 44 36 50" fill="${primary}" opacity="0.3"/><path d="M32 14 Q26 6 32 4 Q38 6 32 14" fill="${secondary}" opacity="0.6"/>`,
+      accent: `<circle cx="32" cy="32" r="4" fill="${secondary}" opacity="0.2"/>`
+    },
+    hanausagi: {
+      body: `<ellipse cx="32" cy="36" rx="10" ry="10" fill="${primary}"/><circle cx="32" cy="28" r="8" fill="${primary}"/>`,
+      eyes: `<circle cx="28" cy="26" r="2.5" fill="${eyeColor}"/><circle cx="28" cy="27" r="1.5" fill="#F85888"/><circle cx="36" cy="26" r="2.5" fill="${eyeColor}"/><circle cx="36" cy="27" r="1.5" fill="#F85888"/>`,
+      details: `<path d="M26 20 Q24 12 22 14" fill="${primary}"/><path d="M38 20 Q40 12 42 14" fill="${primary}"/><circle cx="26" cy="12" r="2" fill="#FF69B4" opacity="0.7"/><circle cx="38" cy="12" r="2" fill="#FF69B4" opacity="0.7"/>`,
+      accent: `<circle cx="26" cy="30" r="1.5" fill="#FFB6C1" opacity="0.5"/><circle cx="38" cy="30" r="1.5" fill="#FFB6C1" opacity="0.5"/>`
+    },
+    tsukiusagi: {
+      body: `<ellipse cx="32" cy="34" rx="12" ry="12" fill="${primary}"/><circle cx="32" cy="24" r="10" fill="${primary}"/>`,
+      eyes: `<circle cx="27" cy="22" r="3" fill="${eyeColor}"/><circle cx="27" cy="22" r="1.8" fill="#F85888"/><circle cx="37" cy="22" r="3" fill="${eyeColor}"/><circle cx="37" cy="22" r="1.8" fill="#F85888"/>`,
+      details: `<path d="M24 16 Q22 6 20 10" fill="${primary}"/><path d="M40 16 Q42 6 44 10" fill="${primary}"/><circle cx="24" cy="8" r="2.5" fill="#E1BEE7" opacity="0.7"/><circle cx="40" cy="8" r="2.5" fill="#E1BEE7" opacity="0.7"/>`,
+      accent: `<circle cx="32" cy="16" r="3" fill="#FFF" opacity="0.2"/><path d="M26 28 Q32 32 38 28" fill="${secondary}" opacity="0.3"/>`
+    },
+    kanamori: {
+      body: `<rect x="18" y="20" width="28" height="28" rx="6" fill="${primary}"/><rect x="22" y="16" width="20" height="20" rx="4" fill="${primary}"/>`,
+      eyes: `<rect x="26" y="22" width="4" height="3" rx="1" fill="${eyeColor}"/><circle cx="28" cy="23" r="1" fill="#333"/><rect x="34" y="22" width="4" height="3" rx="1" fill="${eyeColor}"/><circle cx="36" cy="23" r="1" fill="#333"/>`,
+      details: `<line x1="22" y1="32" x2="42" y2="32" stroke="${dark}" stroke-width="1" opacity="0.3"/><line x1="22" y1="36" x2="42" y2="36" stroke="${dark}" stroke-width="1" opacity="0.3"/><line x1="22" y1="40" x2="42" y2="40" stroke="${dark}" stroke-width="1" opacity="0.3"/>`,
+      accent: ``
+    },
+    kusakabi: {
+      body: `<ellipse cx="32" cy="36" rx="12" ry="10" fill="${primary}"/><circle cx="32" cy="28" r="8" fill="${primary}"/>`,
+      eyes: `<circle cx="28" cy="26" r="2" fill="${eyeColor}"/><circle cx="28" cy="27" r="1.2" fill="#A040A0"/><circle cx="36" cy="26" r="2" fill="${eyeColor}"/><circle cx="36" cy="27" r="1.2" fill="#A040A0"/>`,
+      details: `<circle cx="26" cy="22" r="2" fill="#A040A0" opacity="0.4"/><circle cx="38" cy="24" r="1.5" fill="#A040A0" opacity="0.3"/><path d="M32 20 Q30 16 32 14 Q34 16 32 20" fill="#78C850" opacity="0.6"/>`,
+      accent: ``
+    },
+    dokubana: {
+      body: `<ellipse cx="32" cy="34" rx="14" ry="12" fill="${primary}"/><circle cx="32" cy="24" r="10" fill="${primary}"/>`,
+      eyes: `<ellipse cx="26" cy="22" rx="2.5" ry="2" fill="${eyeColor}"/><circle cx="26" cy="22" r="1.2" fill="#A040A0"/><ellipse cx="38" cy="22" rx="2.5" ry="2" fill="${eyeColor}"/><circle cx="38" cy="22" r="1.2" fill="#A040A0"/>`,
+      details: `<circle cx="28" cy="16" r="3" fill="#CE93D8" opacity="0.6"/><circle cx="36" cy="14" r="3.5" fill="#CE93D8" opacity="0.7"/><circle cx="32" cy="16" r="2.5" fill="#BA68C8" opacity="0.6"/>`,
+      accent: `<path d="M20 30 Q16 34 18 38" fill="${secondary}" opacity="0.3"/><path d="M44 30 Q48 34 46 38" fill="${secondary}" opacity="0.3"/>`
+    },
+    yamigarasu: {
+      body: `<ellipse cx="32" cy="34" rx="14" ry="12" fill="${primary}"/><ellipse cx="32" cy="24" rx="10" ry="9" fill="${primary}"/><path d="M18 28 Q6 18 12 14" fill="${dark}"/><path d="M46 28 Q58 18 52 14" fill="${dark}"/>`,
+      eyes: `<circle cx="27" cy="22" r="2.5" fill="#FF4444" opacity="0.9"/><circle cx="27" cy="22" r="1" fill="#FFF"/><circle cx="37" cy="22" r="2.5" fill="#FF4444" opacity="0.9"/><circle cx="37" cy="22" r="1" fill="#FFF"/>`,
+      details: `<path d="M30 26 L32 30 L34 26" fill="#F8D030" opacity="0.7"/><path d="M32 16 Q28 12 32 10 Q36 12 32 16" fill="${dark}"/>`,
+      accent: ``
+    },
+    yukiusagi: {
+      body: `<ellipse cx="32" cy="36" rx="10" ry="10" fill="${primary}"/><circle cx="32" cy="28" r="8" fill="${primary}"/>`,
+      eyes: `<circle cx="28" cy="26" r="2.5" fill="${eyeColor}"/><circle cx="28" cy="27" r="1.5" fill="#6890F0"/><circle cx="36" cy="26" r="2.5" fill="${eyeColor}"/><circle cx="36" cy="27" r="1.5" fill="#6890F0"/>`,
+      details: `<path d="M26 20 Q24 12 22 14" fill="${primary}"/><path d="M38 20 Q40 12 42 14" fill="${primary}"/>`,
+      accent: `<circle cx="26" cy="30" r="1.5" fill="#B3E5FC" opacity="0.5"/><circle cx="38" cy="30" r="1.5" fill="#B3E5FC" opacity="0.5"/><circle cx="32" cy="20" r="1" fill="#E1F5FE" opacity="0.7"/>`
+    },
+    koorigitsune: {
+      body: `<ellipse cx="32" cy="34" rx="14" ry="12" fill="${primary}"/><ellipse cx="32" cy="22" rx="11" ry="10" fill="${primary}"/><path d="M22 36 Q16 44 20 48" fill="${dark}"/><path d="M42 36 Q48 44 44 48" fill="${dark}"/>`,
+      eyes: `<ellipse cx="26" cy="20" rx="2.5" ry="2" fill="${eyeColor}"/><circle cx="26" cy="20" r="1.5" fill="#EE99AC"/><ellipse cx="38" cy="20" rx="2.5" ry="2" fill="${eyeColor}"/><circle cx="38" cy="20" r="1.5" fill="#EE99AC"/>`,
+      details: `<path d="M24 14 Q20 6 18 10" fill="${primary}"/><path d="M40 14 Q44 6 46 10" fill="${primary}"/><path d="M42 34 Q52 38 54 34" fill="${primary}" opacity="0.7"/>`,
+      accent: `<circle cx="32" cy="16" r="2" fill="#E1F5FE" opacity="0.5"/>`
+    },
+    kogoriiwa: {
+      body: `<path d="M20 44 L16 28 L24 18 L40 18 L48 28 L44 44 Z" fill="${primary}"/><path d="M24 18 L28 10 L36 10 L40 18" fill="${light}"/>`,
+      eyes: `<circle cx="28" cy="28" r="2" fill="${eyeColor}"/><circle cx="28" cy="28" r="1.2" fill="#6890F0"/><circle cx="36" cy="28" r="2" fill="${eyeColor}"/><circle cx="36" cy="28" r="1.2" fill="#6890F0"/>`,
+      details: `<line x1="24" y1="34" x2="40" y2="34" stroke="${dark}" stroke-width="1" opacity="0.3"/><line x1="22" y1="38" x2="42" y2="38" stroke="${dark}" stroke-width="1" opacity="0.3"/>`,
+      accent: ``
+    },
+    tatsunoko: {
+      body: `<ellipse cx="32" cy="34" rx="10" ry="10" fill="${primary}"/><circle cx="32" cy="26" r="8" fill="${primary}"/>`,
+      eyes: `<circle cx="28" cy="24" r="2.5" fill="${eyeColor}"/><circle cx="28" cy="24" r="1.5" fill="#7038F8"/><circle cx="36" cy="24" r="2.5" fill="${eyeColor}"/><circle cx="36" cy="24" r="1.5" fill="#7038F8"/>`,
+      details: `<path d="M26 20 Q24 14 22 16" fill="${dark}" opacity="0.5"/><path d="M38 20 Q40 14 42 16" fill="${dark}" opacity="0.5"/><path d="M38 38 Q44 42 46 38 Q44 44 40 40" fill="${dark}" opacity="0.4"/>`,
+      accent: ``
+    },
+    ryuubi: {
+      body: `<ellipse cx="32" cy="34" rx="14" ry="12" fill="${primary}"/><ellipse cx="32" cy="22" rx="11" ry="10" fill="${primary}"/><path d="M18 28 Q8 22 12 16" fill="${secondary}" opacity="0.6"/><path d="M46 28 Q56 22 52 16" fill="${secondary}" opacity="0.6"/>`,
+      eyes: `<ellipse cx="26" cy="20" rx="2.5" ry="2" fill="${eyeColor}"/><circle cx="26" cy="20" r="1.5" fill="#7038F8"/><ellipse cx="38" cy="20" rx="2.5" ry="2" fill="${eyeColor}"/><circle cx="38" cy="20" r="1.5" fill="#7038F8"/>`,
+      details: `<path d="M24 14 Q20 6 22 4" fill="${dark}" opacity="0.5"/><path d="M40 14 Q44 6 42 4" fill="${dark}" opacity="0.5"/><path d="M40 38 Q50 44 52 38" fill="${dark}" opacity="0.4"/>`,
+      accent: ``
+    },
+    ryuujin: {
+      body: `<ellipse cx="32" cy="32" rx="18" ry="16" fill="${primary}"/><ellipse cx="32" cy="18" rx="13" ry="11" fill="${primary}"/><path d="M14 26 Q2 18 8 10" fill="${secondary}"/><path d="M50 26 Q62 18 56 10" fill="${secondary}"/><rect x="16" y="42" width="10" height="12" rx="3" fill="${dark}"/><rect x="38" y="42" width="10" height="12" rx="3" fill="${dark}"/>`,
+      eyes: `<path d="M22 16 L20 14 L28 15 Z" fill="${eyeColor}"/><circle cx="24" cy="16" r="1.8" fill="#7038F8"/><path d="M42 16 L44 14 L36 15 Z" fill="${eyeColor}"/><circle cx="40" cy="16" r="1.8" fill="#7038F8"/>`,
+      details: `<path d="M22 10 Q16 2 20 0" fill="${dark}"/><path d="M42 10 Q48 2 44 0" fill="${dark}"/><path d="M42 36 Q54 44 56 36" fill="${dark}" opacity="0.5"/>`,
+      accent: `<circle cx="32" cy="26" r="4" fill="${light}" opacity="0.2"/>`
+    },
+    kiokudama: {
+      body: `<circle cx="32" cy="30" r="12" fill="${primary}" opacity="0.85"/>`,
+      eyes: `<circle cx="28" cy="28" r="2.5" fill="${eyeColor}"/><circle cx="28" cy="28" r="1.5" fill="#F85888"/><circle cx="36" cy="28" r="2.5" fill="${eyeColor}"/><circle cx="36" cy="28" r="1.5" fill="#F85888"/>`,
+      details: `<circle cx="32" cy="22" r="2" fill="${light}" opacity="0.5"/><circle cx="28" cy="36" r="1.5" fill="${light}" opacity="0.3"/><circle cx="36" cy="36" r="1.5" fill="${light}" opacity="0.3"/>`,
+      accent: `<circle cx="32" cy="30" r="8" fill="none" stroke="${light}" stroke-width="0.5" opacity="0.4"/>`
+    },
+    omoidama: {
+      body: `<circle cx="32" cy="28" r="14" fill="${primary}" opacity="0.9"/><path d="M22 36 Q20 44 24 46" fill="${primary}" opacity="0.5"/><path d="M42 36 Q44 44 40 46" fill="${primary}" opacity="0.5"/>`,
+      eyes: `<ellipse cx="26" cy="26" rx="3" ry="2.5" fill="${eyeColor}"/><circle cx="26" cy="26" r="1.5" fill="#EE99AC"/><ellipse cx="38" cy="26" rx="3" ry="2.5" fill="${eyeColor}"/><circle cx="38" cy="26" r="1.5" fill="#EE99AC"/>`,
+      details: `<circle cx="32" cy="18" r="3" fill="${secondary}" opacity="0.4"/><circle cx="26" cy="20" r="1.5" fill="${secondary}" opacity="0.3"/><circle cx="38" cy="20" r="1.5" fill="${secondary}" opacity="0.3"/>`,
+      accent: `<circle cx="32" cy="28" r="10" fill="none" stroke="${secondary}" stroke-width="0.5" opacity="0.5"/><circle cx="32" cy="28" r="6" fill="none" stroke="${secondary}" stroke-width="0.3" opacity="0.3"/>`
+    },
+    haganedake: {
+      body: `<path d="M18 44 L14 28 L22 14 L42 14 L50 28 L46 44 Z" fill="${primary}"/><path d="M22 14 L26 6 L38 6 L42 14" fill="${light}"/>`,
+      eyes: `<path d="M24 24 L22 22 L28 23 Z" fill="${eyeColor}"/><circle cx="25" cy="24" r="1.5" fill="#7038F8"/><path d="M40 24 L42 22 L36 23 Z" fill="${eyeColor}"/><circle cx="39" cy="24" r="1.5" fill="#7038F8"/>`,
+      details: `<line x1="20" y1="30" x2="44" y2="30" stroke="${dark}" stroke-width="1" opacity="0.3"/><line x1="18" y1="36" x2="46" y2="36" stroke="${dark}" stroke-width="1" opacity="0.3"/><path d="M28 8 Q32 2 36 8" fill="${secondary}" opacity="0.5"/>`,
+      accent: `<circle cx="32" cy="26" r="3" fill="${secondary}" opacity="0.2"/>`
+    },
+    kurooni: {
+      body: `<ellipse cx="32" cy="34" rx="16" ry="14" fill="${primary}"/><ellipse cx="32" cy="22" rx="12" ry="10" fill="${primary}"/><rect x="16" y="42" width="10" height="10" rx="3" fill="${dark}"/><rect x="38" y="42" width="10" height="10" rx="3" fill="${dark}"/>`,
+      eyes: `<path d="M24 20 L22 18 L28 19 Z" fill="#FF4444"/><circle cx="25" cy="20" r="1.2" fill="#FFF"/><path d="M40 20 L42 18 L36 19 Z" fill="#FF4444"/><circle cx="39" cy="20" r="1.2" fill="#FFF"/>`,
+      details: `<path d="M26 14 Q24 8 26 6" fill="${dark}" opacity="0.7"/><path d="M38 14 Q40 8 38 6" fill="${dark}" opacity="0.7"/>`,
+      accent: ``
+    },
+    fubukirei: {
+      body: `<path d="M32 16 Q18 22 20 40 Q24 48 32 44 Q40 48 44 40 Q46 22 32 16" fill="${primary}" opacity="0.75"/>`,
+      eyes: `<circle cx="28" cy="28" r="2.5" fill="#98D8D8" opacity="0.9"/><circle cx="28" cy="28" r="1" fill="#FFF"/><circle cx="36" cy="28" r="2.5" fill="#98D8D8" opacity="0.9"/><circle cx="36" cy="28" r="1" fill="#FFF"/>`,
+      details: `<path d="M24 36 Q20 44 24 50" fill="${primary}" opacity="0.4"/><path d="M40 36 Q44 44 40 50" fill="${primary}" opacity="0.4"/><circle cx="32" cy="22" r="2" fill="#E1F5FE" opacity="0.5"/>`,
+      accent: ``
+    },
+    umihebi: {
+      body: `<ellipse cx="32" cy="32" rx="18" ry="10" fill="${primary}"/><ellipse cx="22" cy="26" rx="10" ry="8" fill="${primary}"/><path d="M44 28 Q54 26 58 30 Q54 34 48 32" fill="${dark}" opacity="0.5"/>`,
+      eyes: `<ellipse cx="18" cy="24" rx="2" ry="2.5" fill="${eyeColor}"/><circle cx="18" cy="24" r="1.2" fill="#7038F8"/><ellipse cx="26" cy="24" rx="2" ry="2.5" fill="${eyeColor}"/><circle cx="26" cy="24" r="1.2" fill="#7038F8"/>`,
+      details: `<path d="M16 20 Q14 14 16 12" fill="${secondary}" opacity="0.5"/><path d="M28 20 Q30 14 28 12" fill="${secondary}" opacity="0.5"/>`,
+      accent: ``
+    },
+    denjimushi: {
+      body: `<ellipse cx="32" cy="36" rx="12" ry="8" fill="${primary}"/><circle cx="32" cy="28" r="8" fill="${primary}"/>`,
+      eyes: `<circle cx="28" cy="26" r="2" fill="${eyeColor}"/><circle cx="28" cy="27" r="1.2" fill="#F8D030"/><circle cx="36" cy="26" r="2" fill="${eyeColor}"/><circle cx="36" cy="27" r="1.2" fill="#F8D030"/>`,
+      details: `<path d="M22 34 Q18 38 16 36" fill="${dark}" opacity="0.5"/><path d="M42 34 Q46 38 48 36" fill="${dark}" opacity="0.5"/><path d="M24 34 Q20 40 18 38" fill="${dark}" opacity="0.3"/><path d="M40 34 Q44 40 46 38" fill="${dark}" opacity="0.3"/>`,
+      accent: `<path d="M28 22 Q32 18 36 22" fill="#FFEB3B" opacity="0.4"/>`
+    },
+    raijindou: {
+      body: `<ellipse cx="32" cy="34" rx="16" ry="12" fill="${primary}"/><ellipse cx="32" cy="22" rx="12" ry="10" fill="${primary}"/><rect x="16" y="40" width="10" height="10" rx="3" fill="${dark}"/><rect x="38" y="40" width="10" height="10" rx="3" fill="${dark}"/>`,
+      eyes: `<path d="M24 20 L22 18 L28 19 Z" fill="${eyeColor}"/><circle cx="25" cy="20" r="1.5" fill="#F8D030"/><path d="M40 20 L42 18 L36 19 Z" fill="${eyeColor}"/><circle cx="39" cy="20" r="1.5" fill="#F8D030"/>`,
+      details: `<path d="M24 14 Q20 6 24 4" fill="${secondary}" opacity="0.6"/><path d="M40 14 Q44 6 40 4" fill="${secondary}" opacity="0.6"/><path d="M32 12 Q28 4 32 2 Q36 4 32 12" fill="#FFEB3B" opacity="0.5"/>`,
+      accent: `<circle cx="32" cy="28" r="3" fill="#FFEB3B" opacity="0.2"/>`
+    },
+    omoide: {
+      body: `<circle cx="32" cy="26" r="14" fill="${primary}" opacity="0.9"/><path d="M22 34 Q18 44 22 48 Q26 50 28 42" fill="${primary}" opacity="0.6"/><path d="M42 34 Q46 44 42 48 Q38 50 36 42" fill="${primary}" opacity="0.6"/>`,
+      eyes: `<ellipse cx="26" cy="24" rx="3.5" ry="3" fill="${eyeColor}"/><circle cx="26" cy="24" r="2" fill="#F85888"/><ellipse cx="38" cy="24" rx="3.5" ry="3" fill="${eyeColor}"/><circle cx="38" cy="24" r="2" fill="#F85888"/>`,
+      details: `<circle cx="32" cy="14" r="3" fill="${secondary}" opacity="0.6"/><circle cx="24" cy="16" r="2" fill="${secondary}" opacity="0.4"/><circle cx="40" cy="16" r="2" fill="${secondary}" opacity="0.4"/>`,
+      accent: `<circle cx="32" cy="26" r="10" fill="none" stroke="${secondary}" stroke-width="0.5" opacity="0.6"/><circle cx="32" cy="26" r="14" fill="none" stroke="${secondary}" stroke-width="0.3" opacity="0.3"/><circle cx="32" cy="26" r="18" fill="none" stroke="${secondary}" stroke-width="0.2" opacity="0.15"/>`
+    },
+    wasurenu: {
+      body: `<ellipse cx="32" cy="28" rx="16" ry="14" fill="${primary}" opacity="0.85"/><path d="M18 34 Q12 44 16 50 Q22 54 24 42" fill="${primary}" opacity="0.5"/><path d="M46 34 Q52 44 48 50 Q42 54 40 42" fill="${primary}" opacity="0.5"/>`,
+      eyes: `<ellipse cx="24" cy="24" rx="4" ry="3" fill="#FF4444" opacity="0.9"/><circle cx="24" cy="24" r="1.5" fill="#FFF"/><ellipse cx="40" cy="24" rx="4" ry="3" fill="#FF4444" opacity="0.9"/><circle cx="40" cy="24" r="1.5" fill="#FFF"/>`,
+      details: `<path d="M26 16 Q24 8 28 6 Q32 10 26 16" fill="${dark}" opacity="0.6"/><path d="M38 16 Q40 8 36 6 Q32 10 38 16" fill="${dark}" opacity="0.6"/>`,
+      accent: `<circle cx="32" cy="28" r="12" fill="none" stroke="${dark}" stroke-width="0.5" opacity="0.5"/><circle cx="32" cy="28" r="16" fill="none" stroke="${dark}" stroke-width="0.3" opacity="0.3"/><path d="M20 32 Q16 40 20 46" fill="${primary}" opacity="0.3"/><path d="M44 32 Q48 40 44 46" fill="${primary}" opacity="0.3"/>`
+    }
+  };
+
+  return sprites[id] || null;
+}
+
+function renderSpriteSVG(id, types) {
+  const primary = getTypeColor(types);
+  const secondary = getSecondaryColor(types);
+  const shape = getSpriteShape(id, primary, secondary);
+  if (!shape) return '';
+
+  return `<svg viewBox="0 0 64 64" width="72" height="72">
+    <defs><radialGradient id="glow-${id}" cx="50%" cy="40%" r="50%">
+      <stop offset="0%" stop-color="${primary}" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="${primary}" stop-opacity="0"/>
+    </radialGradient></defs>
+    <circle cx="32" cy="32" r="28" fill="url(#glow-${id})"/>
+    ${shape.body}${shape.details}${shape.accent || ''}${shape.eyes}
+  </svg>`;
+}
+
+// ─── Monster Data ───
+const monsters = [
+  { num:1, id:"himori", name:"ヒモリ", types:["fire"], stats:{hp:45,atk:60,def:40,spAtk:50,spDef:40,speed:65}, evo:[{name:"ヒノモリ",lv:16}], area:"starter", legendary:false },
+  { num:2, id:"hinomori", name:"ヒノモリ", types:["fire"], stats:{hp:60,atk:80,def:55,spAtk:65,spDef:55,speed:80}, evo:[{name:"エンジュウ",lv:36}], area:"starter", legendary:false },
+  { num:3, id:"enjuu", name:"エンジュウ", types:["fire","fighting"], stats:{hp:76,atk:104,def:71,spAtk:80,spDef:71,speed:108}, evo:[], area:"starter", legendary:false },
+  { num:4, id:"shizukumo", name:"シズクモ", types:["water"], stats:{hp:50,atk:40,def:45,spAtk:60,spDef:50,speed:55}, evo:[{name:"ナミコゾウ",lv:16}], area:"starter", legendary:false },
+  { num:5, id:"namikozou", name:"ナミコゾウ", types:["water"], stats:{hp:65,atk:55,def:60,spAtk:80,spDef:65,speed:70}, evo:[{name:"タイカイオウ",lv:36}], area:"starter", legendary:false },
+  { num:6, id:"taikaiou", name:"タイカイオウ", types:["water","psychic"], stats:{hp:81,atk:71,def:76,spAtk:104,spDef:81,speed:97}, evo:[], area:"starter", legendary:false },
+  { num:7, id:"konohana", name:"コノハナ", types:["grass"], stats:{hp:55,atk:45,def:55,spAtk:45,spDef:55,speed:45}, evo:[{name:"モリノコ",lv:16}], area:"starter", legendary:false },
+  { num:8, id:"morinoko", name:"モリノコ", types:["grass"], stats:{hp:70,atk:60,def:70,spAtk:60,spDef:70,speed:60}, evo:[{name:"タイジュシン",lv:36}], area:"starter", legendary:false },
+  { num:9, id:"taijushin", name:"タイジュシン", types:["grass","rock"], stats:{hp:95,atk:82,def:97,spAtk:75,spDef:87,speed:74}, evo:[], area:"starter", legendary:false },
+  { num:10, id:"konezumi", name:"コネズミ", types:["normal"], stats:{hp:30,atk:56,def:35,spAtk:25,spDef:35,speed:72}, evo:[{name:"オオネズミ",lv:20}], area:"early", legendary:false },
+  { num:11, id:"oonezumi", name:"オオネズミ", types:["normal"], stats:{hp:55,atk:81,def:60,spAtk:50,spDef:60,speed:97}, evo:[], area:"early", legendary:false },
+  { num:12, id:"tobibato", name:"トビバト", types:["normal","flying"], stats:{hp:40,atk:45,def:40,spAtk:35,spDef:35,speed:56}, evo:[{name:"ハヤテドリ",lv:18}], area:"early", legendary:false },
+  { num:13, id:"hayatedori", name:"ハヤテドリ", types:["normal","flying"], stats:{hp:63,atk:70,def:55,spAtk:50,spDef:50,speed:91}, evo:[], area:"early", legendary:false },
+  { num:14, id:"mayumushi", name:"マユムシ", types:["bug"], stats:{hp:45,atk:30,def:55,spAtk:25,spDef:25,speed:30}, evo:[{name:"ハナムシ",lv:10}], area:"early", legendary:false },
+  { num:15, id:"hanamushi", name:"ハナムシ", types:["bug","flying"], stats:{hp:60,atk:45,def:50,spAtk:80,spDef:80,speed:70}, evo:[], area:"early", legendary:false },
+  { num:16, id:"hikarineko", name:"ヒカリネコ", types:["electric"], stats:{hp:40,atk:50,def:35,spAtk:65,spDef:50,speed:90}, evo:[], area:"early", legendary:false },
+  { num:17, id:"dokudama", name:"ドクダマ", types:["poison"], stats:{hp:40,atk:40,def:35,spAtk:40,spDef:40,speed:45}, evo:[{name:"ドクヌマ",lv:22}], area:"early", legendary:false },
+  { num:18, id:"dokunuma", name:"ドクヌマ", types:["poison","ground"], stats:{hp:65,atk:65,def:60,spAtk:65,spDef:60,speed:55}, evo:[], area:"early", legendary:false },
+  { num:19, id:"kawadojou", name:"カワドジョウ", types:["water","ground"], stats:{hp:55,atk:55,def:60,spAtk:45,spDef:55,speed:50}, evo:[], area:"early", legendary:false },
+  { num:20, id:"hidane", name:"ヒダネ", types:["fire"], stats:{hp:50,atk:65,def:40,spAtk:45,spDef:40,speed:60}, evo:[{name:"カエンジシ",lv:30}], area:"mid", legendary:false },
+  { num:21, id:"kaenjishi", name:"カエンジシ", types:["fire","normal"], stats:{hp:76,atk:98,def:65,spAtk:68,spDef:65,speed:93}, evo:[], area:"mid", legendary:false },
+  { num:22, id:"tsuchikobushi", name:"ツチコブシ", types:["fighting"], stats:{hp:55,atk:70,def:55,spAtk:30,spDef:40,speed:45}, evo:[{name:"イワケンジン",lv:32}], area:"mid", legendary:false },
+  { num:23, id:"iwakenjin", name:"イワケンジン", types:["fighting","rock"], stats:{hp:80,atk:105,def:85,spAtk:40,spDef:55,speed:55}, evo:[], area:"mid", legendary:false },
+  { num:24, id:"mogurakko", name:"モグラッコ", types:["ground"], stats:{hp:50,atk:55,def:50,spAtk:35,spDef:40,speed:60}, evo:[{name:"ドゴウ",lv:28}], area:"mid", legendary:false },
+  { num:25, id:"dogou", name:"ドゴウ", types:["ground","steel"], stats:{hp:75,atk:90,def:85,spAtk:45,spDef:60,speed:75}, evo:[], area:"mid", legendary:false },
+  { num:26, id:"yurabi", name:"ユラビ", types:["ghost"], stats:{hp:35,atk:25,def:30,spAtk:60,spDef:45,speed:55}, evo:[{name:"カゲボウシ",lv:25}], area:"mid", legendary:false },
+  { num:27, id:"kageboushi", name:"カゲボウシ", types:["ghost","psychic"], stats:{hp:50,atk:40,def:45,spAtk:85,spDef:65,speed:70}, evo:[{name:"ヨミカグラ",lv:40}], area:"mid", legendary:false },
+  { num:28, id:"yomikagura", name:"ヨミカグラ", types:["ghost","psychic"], stats:{hp:65,atk:55,def:60,spAtk:115,spDef:90,speed:90}, evo:[], area:"mid", legendary:false },
+  { num:29, id:"hanausagi", name:"ハナウサギ", types:["fairy"], stats:{hp:50,atk:35,def:40,spAtk:60,spDef:55,speed:55}, evo:[{name:"ツキウサギ",lv:30}], area:"mid", legendary:false },
+  { num:30, id:"tsukiusagi", name:"ツキウサギ", types:["fairy","psychic"], stats:{hp:70,atk:50,def:60,spAtk:95,spDef:85,speed:80}, evo:[], area:"mid", legendary:false },
+  { num:31, id:"kanamori", name:"カナモリ", types:["steel"], stats:{hp:65,atk:70,def:100,spAtk:40,spDef:70,speed:30}, evo:[], area:"mid", legendary:false },
+  { num:32, id:"kusakabi", name:"クサカビ", types:["poison","grass"], stats:{hp:45,atk:35,def:40,spAtk:55,spDef:50,speed:40}, evo:[{name:"ドクバナ",lv:32}], area:"mid", legendary:false },
+  { num:33, id:"dokubana", name:"ドクバナ", types:["poison","grass"], stats:{hp:70,atk:55,def:65,spAtk:90,spDef:80,speed:60}, evo:[], area:"mid", legendary:false },
+  { num:34, id:"yamigarasu", name:"ヤミガラス", types:["dark","flying"], stats:{hp:55,atk:75,def:50,spAtk:60,spDef:50,speed:80}, evo:[], area:"mid", legendary:false },
+  { num:35, id:"yukiusagi", name:"ユキウサギ", types:["ice"], stats:{hp:45,atk:40,def:45,spAtk:60,spDef:50,speed:65}, evo:[{name:"コオリギツネ",lv:34}], area:"late", legendary:false },
+  { num:36, id:"koorigitsune", name:"コオリギツネ", types:["ice","fairy"], stats:{hp:65,atk:55,def:60,spAtk:95,spDef:80,speed:100}, evo:[], area:"late", legendary:false },
+  { num:37, id:"kogoriiwa", name:"コゴリイワ", types:["ice","rock"], stats:{hp:80,atk:90,def:95,spAtk:40,spDef:55,speed:30}, evo:[], area:"late", legendary:false },
+  { num:38, id:"tatsunoko", name:"タツノコ", types:["dragon"], stats:{hp:45,atk:55,def:45,spAtk:55,spDef:45,speed:50}, evo:[{name:"リュウビ",lv:30}], area:"late", legendary:false },
+  { num:39, id:"ryuubi", name:"リュウビ", types:["dragon","flying"], stats:{hp:65,atk:75,def:60,spAtk:75,spDef:60,speed:70}, evo:[{name:"リュウジン",lv:48}], area:"late", legendary:false },
+  { num:40, id:"ryuujin", name:"リュウジン", types:["dragon","flying"], stats:{hp:90,atk:110,def:80,spAtk:100,spDef:80,speed:95}, evo:[], area:"late", legendary:false },
+  { num:41, id:"kiokudama", name:"キオクダマ", types:["psychic"], stats:{hp:55,atk:30,def:50,spAtk:70,spDef:55,speed:45}, evo:[{name:"オモイダマ",lv:36}], area:"late", legendary:false },
+  { num:42, id:"omoidama", name:"オモイダマ", types:["psychic","fairy"], stats:{hp:75,atk:45,def:70,spAtk:105,spDef:90,speed:60}, evo:[], area:"late", legendary:false },
+  { num:43, id:"haganedake", name:"ハガネダケ", types:["steel","dragon"], stats:{hp:70,atk:95,def:105,spAtk:60,spDef:80,speed:50}, evo:[], area:"late", legendary:false },
+  { num:44, id:"kurooni", name:"クロオニ", types:["dark","fighting"], stats:{hp:80,atk:100,def:70,spAtk:50,spDef:60,speed:85}, evo:[], area:"late", legendary:false },
+  { num:45, id:"fubukirei", name:"フブキレイ", types:["ghost","ice"], stats:{hp:55,atk:40,def:55,spAtk:95,spDef:85,speed:80}, evo:[], area:"late", legendary:false },
+  { num:46, id:"umihebi", name:"ウミヘビ", types:["water","dragon"], stats:{hp:75,atk:60,def:70,spAtk:90,spDef:75,speed:80}, evo:[], area:"late", legendary:false },
+  { num:47, id:"denjimushi", name:"デンジムシ", types:["electric","steel"], stats:{hp:50,atk:55,def:65,spAtk:55,spDef:50,speed:40}, evo:[{name:"ライジンドウ",lv:38}], area:"late", legendary:false },
+  { num:48, id:"raijindou", name:"ライジンドウ", types:["electric","steel"], stats:{hp:70,atk:80,def:95,spAtk:85,spDef:75,speed:60}, evo:[], area:"late", legendary:false },
+  { num:49, id:"omoide", name:"オモイデ", types:["psychic","fairy"], stats:{hp:100,atk:65,def:90,spAtk:130,spDef:120,speed:95}, evo:[], area:"legendary", legendary:true },
+  { num:50, id:"wasurenu", name:"ワスレヌ", types:["psychic","dark"], stats:{hp:100,atk:130,def:80,spAtk:120,spDef:80,speed:90}, evo:[], area:"legendary", legendary:true },
+];
+
+// ─── Render ───
+const grid = document.getElementById('monsterGrid');
+const filterBar = document.getElementById('filterBar');
+
+let activeFilter = 'all';
+
+// Build filter buttons
+const typesList = ['all', ...Object.keys(TYPE_LABEL)];
+typesList.forEach(t => {
+  const btn = document.createElement('button');
+  btn.className = 'filter-btn' + (t === 'all' ? ' active' : '');
+  btn.textContent = t === 'all' ? 'すべて' : TYPE_LABEL[t];
+  if (t !== 'all') btn.style.borderColor = TYPE_HEX[t] + '80';
+  btn.onclick = () => {
+    activeFilter = t;
+    document.querySelectorAll('.filter-btn').forEach(b => b.classList.remove('active'));
+    btn.classList.add('active');
+    renderGrid();
+  };
+  filterBar.appendChild(btn);
+});
+
+function getStatColor(val) {
+  if (val >= 100) return '#34D399';
+  if (val >= 70) return '#FBBF24';
+  return '#EF4444';
+}
+
+function getStatClass(val) {
+  if (val >= 100) return 'stat-high';
+  if (val >= 70) return 'stat-mid';
+  return 'stat-low';
+}
+
+function renderGrid() {
+  const filtered = activeFilter === 'all'
+    ? monsters
+    : monsters.filter(m => m.types.includes(activeFilter));
+
+  if (filtered.length === 0) {
+    grid.innerHTML = '<div class="empty">該当するモンスターがいません</div>';
+    return;
+  }
+
+  grid.innerHTML = filtered.map((m, i) => {
+    const total = Object.values(m.stats).reduce((a,b) => a+b, 0);
+    const statLabels = ['HP','ATK','DEF','SpA','SpD','SPD'];
+    const statKeys = ['hp','atk','def','spAtk','spDef','speed'];
+
+    const statsHTML = statKeys.map((k, j) => {
+      const v = m.stats[k];
+      const pct = Math.min(100, (v / 160) * 100);
+      return `<div class="stat">
+        <div class="stat-label">${statLabels[j]}</div>
+        <div class="stat-value ${getStatClass(v)}">${v}</div>
+        <div class="stat-bar"><div class="stat-fill" style="width:${pct}%;background:${getStatColor(v)}"></div></div>
+      </div>`;
+    }).join('');
+
+    const typesHTML = m.types.map(t =>
+      `<span class="type-badge" style="background:${TYPE_HEX[t]}">${TYPE_LABEL[t]}</span>`
+    ).join('');
+
+    const evoHTML = m.evo.length > 0
+      ? `<div class="evolution"><span class="evo-arrow">→</span> <span class="evo-name">${m.evo[0].name}</span> (Lv.${m.evo[0].lv})</div>`
+      : '';
+
+    const legendBadge = m.legendary ? '<div class="legend-badge">LEGEND</div>' : '';
+
+    return `<div class="card${m.legendary ? ' legendary' : ''}" style="animation-delay:${i * 0.03}s">
+      ${legendBadge}
+      <div class="card-top">
+        <div class="sprite-container">${renderSpriteSVG(m.id, m.types)}</div>
+        <div class="card-info">
+          <div class="card-number">No.${String(m.num).padStart(3,'0')}</div>
+          <div class="card-name">${m.name}</div>
+          <div class="card-id">${m.id}</div>
+          <div class="types">${typesHTML}</div>
+        </div>
+      </div>
+      <div class="stats">${statsHTML}</div>
+      <div class="stat-total">合計 <span>${total}</span></div>
+      ${evoHTML}
+    </div>`;
+  }).join('');
+}
+
+renderGrid();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- 全50種のモンスターを紹介するスタンドアロンHTMLページ `pokedex.html` を追加
- ゲーム内と同じプロシージャルSVGスプライトを全種族分埋め込み
- 18タイプ対応のフィルターボタン、種族値バーグラフ、進化情報を表示
- ゲームUIと統一されたダークテーマデザイン（RPG風ウィンドウフレーム）

## Details
- 外部依存はGoogle Fonts（Noto Sans JP, Press Start 2P）のみ
- ブラウザで直接開くだけで動作（ビルド不要）
- 伝説モンスター（オモイデ・ワスレヌ）にはゴールドの「LEGEND」バッジ
- 種族値は色分け表示（緑:100+、黄:70-99、赤:70未満）

## Test plan
- [ ] `pokedex.html` をブラウザで開き、全50種が表示されることを確認
- [ ] タイプフィルターで各タイプの絞り込みが正しく動作することを確認
- [ ] モバイル表示でレスポンシブレイアウトが崩れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)