### PR TITLE
docs: CLAUDE.mdにE2E・マップ・スプライト・セーブ・オーディオ情報を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,16 +7,20 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ```bash
 bun run dev              # Next.js 開発サーバー起動
 bun run build            # プロダクションビルド
-bun run test             # テスト実行（全件）
-bun run test:watch       # テスト実行（ウォッチモード）
+bun run test             # ユニットテスト実行（全件, vitest）
+bun run test:watch       # ユニットテスト実行（ウォッチモード）
 bun run test <path>      # 単一テストファイル実行（例: bun run test src/engine/battle/__tests__/damage.test.ts）
 bun run type-check       # TypeScript 型チェック
 bun run lint             # ESLint
 bun run format           # Prettier フォーマット適用
 bun run format:check     # Prettier フォーマットチェック（CIと同じ）
+bun run test:e2e                            # E2Eテスト全件（Playwright）
+bun run test:e2e --project=desktop-chromium  # デスクトップのみ
+bun run test:e2e --project=mobile-chrome     # モバイルのみ
+bun run test:e2e e2e/tests/25-full-playthrough.spec.ts  # 単一E2Eテスト
 ```
 
-**CI は `type-check` → `lint` → `format:check` → `test` → `build` の順で実行される。コミット前に `bun run format` を必ず実行すること。**
+**CI は `type-check` → `lint` → `format:check` → `test` → `build` → `e2e`（desktop-chromiumのみ）の順で実行される。コミット前に `bun run format` を必ず実行すること。**
 
 ## Architecture
 
@@ -24,17 +28,17 @@ bun run format:check     # Prettier フォーマットチェック（CIと同じ
 
 ```
 src/types/index.ts          ← 全グローバル型定義（MonsterSpecies, MoveDefinition, etc.）
-src/data/                   ← マスターデータ（monsters/, moves/, gyms/, items/）
+src/data/                   ← マスターデータ（monsters/, moves/, gyms/, items/, maps/, sprites/）
 src/engine/                 ← 純粋なゲームロジック（副作用なし、React非依存）
 src/engine/state/           ← GameState / GameAction / gameReducer
 src/components/GameProvider ← useReducer + Context で状態配信
-src/components/Game.tsx     ← screen に応じた画面切り替え
+src/components/Game.tsx     ← screen に応じた画面切り替え + マップ遷移時のイベント処理
 src/components/screens/     ← 各画面コンポーネント
 ```
 
 ### パスエイリアス
 
-`@/` → `./src/`（tsconfig.json + vitest.config.ts で設定済み）。常に `@/` を使い、相対パスは避ける。
+`@/` → `./src/`（tsconfig.json + vitest.config.ts で設定済み）。常に `@/` を使い、相対パスは避ける。E2Eテスト（`e2e/`）は `src/` 外なので `@/` は使わず相対パスを使う。
 
 ### ゲーム状態管理
 
@@ -57,13 +61,53 @@ src/components/screens/     ← 各画面コンポーネント
 - `turn-order.ts`: 行動順決定。`TurnAction` に `statStages` を含む
 - `experience.ts`: 経験値計算。`expForLevel(level, expGroup)` で経験値カーブを管理
 
+### イベントスクリプト (`src/engine/event/`)
+
+`EventScript` = `EventCommand[]`。コマンド種別: `dialogue`, `set_flag`, `branch`, `heal`, `give_item`, `battle`, `move_player`, `wait`。`branch` コマンドで `storyFlags` の条件分岐を行う。
+
+**重要**: `Game.tsx` の `handleMapTransition` で `OBLIVION_EVENTS` を順にチェックし、最初に `outputs.length > 0` のイベントで `break` する。完了済みイベントの `then` ブランチは必ず空配列 `[]` を返すこと（非空だと後続イベントがブロックされる）。
+
+### マップ定義 (`src/data/maps/`)
+
+`MapDefinition` 型: `tiles[][]`（"wall"|"ground"|"grass"|"water"|"ledge"|"door"|"sign"）、`connections[]`（マップ遷移）、`encounters[]`（野生テーブル）、`npcs[]`。
+
+- 町は10×10、ルートは12×10（route-1のみ15×10）が基本
+- 接続は南北で2マス幅のペア。`requirement` で条件付き通過、`blockedMessage` で条件未達メッセージ
+- `wasuremachi.ts`, `route-1.ts`, `hajimari-forest.ts` は個別ファイル、残りは `all-maps.ts` に統合
+- `ALL_MAPS` レコードで `getMapById()` 検索
+
 ### モンスターデータ (`src/data/monsters/`)
 
 `starters.ts`, `early-monsters.ts`, `mid-monsters.ts`, `late-monsters.ts`, `legendary.ts` に分割。`index.ts` の `ALL_SPECIES` で統合、`getSpeciesById()` で検索。現在50種。
 
-### イベントスクリプト (`src/engine/event/`)
+### スプライト (`src/data/sprites/`)
 
-`EventScript` = `EventCommand[]`。コマンド種別: `dialogue`, `set_flag`, `branch`, `heal`, `give_item`, `battle`, `move_player`, `wait`。`branch` コマンドで `storyFlags` の条件分岐を行う。
+`PixelSpriteData` = `{ palette: Record<string, string>, grid: string[] }`。20×20グリッド文字列でピクセルアート定義。`'.'`=透明, `'1'`=主色, `'2'`=副色, `'3'`=暗色, `'w'`=白, `'-'`=黒, `'4'`〜`'f'`=固有色（palette定義）。`getSpriteData(speciesId)` で取得。
+
+### セーブ/ロード (`src/engine/state/save-data.ts`)
+
+`localStorage["pokemon_save_{slot}"]` にJSON保存（slot 0-2）。`SAVE_DATA_VERSION = 1`。Set→string[]変換でシリアライズ。高レベルAPI: `saveGame(state, slot, playTime)` / `loadGame(slot)`。オートセーブはslot 0、5秒デバウンス、トリガー: `battle_end`, `map_transition`, `healing`, `starter_selected`, `item_obtained`。
+
+### オーディオ (`src/engine/audio/`)
+
+`createBgmManager()` / `createSeManager()` でファクトリ生成。マネージャーはロジック（イベントログ発行）のみ担当し、実際のオーディオ再生はUIコンポーネント層が `getEventLog()` を監視して実装する。BGMコンテキスト: `title`, `overworld`, `battle_*`, `victory`, `healing`, `evolution`, `event`。SE定数: `SE.ATTACK_NORMAL`, `SE.DAMAGE`, `SE.CURSOR_MOVE` 等。
+
+## E2E テスト (`e2e/`)
+
+### GamePage カスタムfixture (`e2e/fixtures/game-fixture.ts`)
+
+全テストの基盤。主要メソッド: `goto()`, `startNewGame(name)`, `continueGame()`, `selectStarter(index)`, `move(direction, steps)`, `selectFight(moveIndex)`, `selectRun()`, `openMenu()`, `advanceMessage()`, `injectSaveData(data, slot)`, `seedRandom(seed)`。
+
+### セーブデータファクトリ (`e2e/fixtures/save-data.ts`)
+
+テスト用セーブデータ生成関数: `createNewGameSave()`, `createBattleReadySave()`, `createMidGameSave()`, `createPreLeagueSave()` 等。
+
+### テスト規約
+
+- `beforeEach` でセーブデータ注入 + `seedRandom()` 設定が標準パターン
+- 確率依存テストは `test.skip()` でスキップ
+- 画面状態確認に `aria-label` を使用（例: `[aria-label^="バトル:"]`）
+- Playwright設定: Desktop 960×640, Mobile iPhone 12 375×667。CI環境で2回リトライ、4 workers
 
 ## Data Model Quick Reference
 


### PR DESCRIPTION
## Summary

- E2Eテストコマンド・Playwright設定・GamePage fixture・テスト規約を追加
- CI順序にe2eステップを反映
- マップ定義（MapDefinition構造、町/ルートサイズ規約、接続パターン）を追加
- スプライト定義（PixelSpriteData仕様、グリッド文字凡例）を追加
- セーブ/ロードシステム（localStorage保存先、オートセーブ仕様）を追加
- オーディオシステム（BGM/SEマネージャー、UIレイヤー委譲設計）を追加
- イベントスクリプトの重要な注意点（OBLIVION_EVENTSのbreakパターン）を追加

## Test plan

- [x] CLAUDE.mdの内容がコードベースの実態と一致していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)