### PR TITLE
fix: メニューからサブ画面が表示されないバグを修正

### DIFF
--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -1137,7 +1137,7 @@ export function Game() {
         return null;
     }
 
-    return <div className="absolute inset-0 z-50">{content}</div>;
+    return <div className="fixed inset-0 z-50">{content}</div>;
   };
 
   // メイン画面の描画


### PR DESCRIPTION
## Summary
- メニューから「ポケモン」「図鑑」「バッグ」を選択してもサブ画面が表示されず、カーソルが反応しなくなるバグを修正
- `renderOverlay` のラッパー `div` の CSS ポジショニングを `absolute` → `fixed` に変更

## 原因
- `MenuScreen` は `fixed inset-0 z-40` で正しく表示されていた
- `PartyScreen` / `PokedexScreen` / `BagScreen` は `position: static` + `h-full w-full`
- ラッパーが `absolute` だったため、内部のサブ画面がビューポート全体に正しく展開されなかった

## 修正内容
```diff
- return <div className="absolute inset-0 z-50">{content}</div>;
+ return <div className="fixed inset-0 z-50">{content}</div>;
```

## Test plan
- [x] `bun run test` — 全518ユニットテスト合格
- [ ] メニュー → 「ポケモン」→ PartyScreen が表示されることを確認
- [ ] メニュー → 「図鑑」→ PokedexScreen が表示されることを確認
- [ ] メニュー → 「バッグ」→ BagScreen が表示されることを確認
- [ ] 各画面でキーボード操作（カーソル移動、Escape）が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)