### PR TITLE
fix: バトルメッセージ順次表示のキュー機能導入

### DIFF
--- a/src/engine/item/__tests__/item-use.test.ts
+++ b/src/engine/item/__tests__/item-use.test.ts
@@ -240,9 +240,7 @@ describe("canUseItem", () => {
         { moveId: "ember", currentPp: 5 },
       ],
     });
-    expect(canUseItem({ type: "heal_pp", amount: 10 }, ppFull, mhp1, testMoveResolver)).toBe(
-      false,
-    );
+    expect(canUseItem({ type: "heal_pp", amount: 10 }, ppFull, mhp1, testMoveResolver)).toBe(false);
     expect(canUseItem({ type: "heal_pp", amount: 10 }, ppLow, mhp2, testMoveResolver)).toBe(true);
     // moveResolverなしではfalse
     expect(canUseItem({ type: "heal_pp", amount: 10 }, ppLow, mhp2)).toBe(false);


### PR DESCRIPTION
## Summary

- バトル中のターン処理で複数メッセージが生成される際、最後のメッセージしか表示されない問題を修正
- メッセージキュー（`battleMessageIndex`）を導入し、1メッセージずつ順次表示する仕組みに変更
- クリック/キー入力（Enter/Z/Space）でメッセージ送り、3秒放置で自動進行

## 修正内容

### `src/components/Game.tsx`
- `battleMessageIndex` state 追加
- `advanceBattleMessage` コールバック新設（全メッセージ表示後にバトル終了判定/強制交代/処理完了を実行）
- `handleBattleAction`, `handlePartySelect`, `handleBagUse` の `setTimeout(1500)` を削除し、メッセージキュー方式に移行
- 野生モンスター遭遇・トレーナーバトル開始時の `setTimeout` も削除

### `src/components/screens/BattleScreen.tsx`
- `messageIndex` / `onAdvanceMessage` props 追加
- 表示を `messages[messages.length - 1]` → `messages[messageIndex]` に変更
- `isProcessing` 中のキー入力で `onAdvanceMessage()` を呼び出し
- メッセージウィンドウにクリックハンドラ追加
- 次メッセージがある場合に▼インジケータ（bounceアニメーション）を表示
- 3秒自動進行タイマー useEffect 追加

## 修正前の問題

- 逃げる選択後、逃走失敗メッセージが見えずにダメージだけ受ける
- プレイヤーの攻撃メッセージが表示されず、相手の攻撃メッセージだけ見える
- アイテム使用メッセージが飛ばされる

## Test plan

- [x] `bun run type-check` — 新規型エラーなし（既存のe2e/item-use型エラーのみ）
- [x] `bun run test` — 1810テスト通過（既存のflavor-text失敗のみ）
- [x] `bun run format` — フォーマット済み
- [ ] 手動確認: 逃げる → 逃走失敗メッセージ → 相手攻撃メッセージ の順次表示
- [ ] 手動確認: 技使用 → プレイヤー攻撃 → 相手攻撃 の順次表示
- [ ] 手動確認: クリック/Enter でメッセージ送り
- [ ] 手動確認: 3秒放置で自動進行

🤖 Generated with [Claude Code](https://claude.com/claude-code)